### PR TITLE
Add Introductions

### DIFF
--- a/conversations/src/context.rs
+++ b/conversations/src/context.rs
@@ -6,9 +6,11 @@ use crate::{
     conversation::{ConversationId, ConversationIdOwned, ConversationStore},
     identity::Identity,
     inbox::Inbox,
+    proto,
     types::{ContentData, PayloadData},
 };
 
+pub use crate::inbox::Introduction;
 // This is the main entry point to the conversations api.
 // Ctx manages lifetimes of objects to process and generate payloads.
 pub struct Context {
@@ -30,17 +32,16 @@ impl Context {
 
     pub fn create_private_convo(
         &mut self,
-        remote_bundle: &PrekeyBundle,
+        remote_bundle: &Introduction,
         content: String,
-    ) -> ConversationIdOwned {
-        let (convo, _payloads) = self
+    ) -> (ConversationIdOwned, Vec<proto::EncryptedPayload>) {
+        let (convo, payloads) = self
             .inbox
             .invite_to_private_convo(remote_bundle, content)
             .unwrap_or_else(|_| todo!("Log/Surface Error"));
 
-        self.store.insert_convo(convo)
-
-        // TODO: Change return type to handle outbout packets.
+        let convo_id = self.store.insert_convo(convo);
+        (convo_id, payloads)
     }
 
     pub fn send_content(&mut self, _convo_id: ConversationId, _content: &[u8]) -> Vec<PayloadData> {

--- a/conversations/src/errors.rs
+++ b/conversations/src/errors.rs
@@ -12,4 +12,8 @@ pub enum ChatError {
     BadBundleValue(String),
     #[error("handshake initiated with a unknown ephemeral key")]
     UnknownEphemeralKey(),
+    #[error("expected a different key length")]
+    InvalidKeyLength,
+    #[error("bytes provided to {0} failed")]
+    BadParsing(&'static str),
 }

--- a/conversations/src/inbox.rs
+++ b/conversations/src/inbox.rs
@@ -1,4 +1,6 @@
 mod handshake;
 mod inbox;
+mod introduction;
 
 pub use inbox::Inbox;
+pub use introduction::Introduction;

--- a/conversations/src/inbox/introduction.rs
+++ b/conversations/src/inbox/introduction.rs
@@ -1,0 +1,65 @@
+use crypto::PrekeyBundle;
+use x25519_dalek::PublicKey;
+
+use crate::errors::ChatError;
+
+/// Supplies remote participants with the required keys to use Inbox protocol
+pub struct Introduction {
+    pub installation_key: PublicKey,
+    pub ephemeral_key: PublicKey,
+}
+
+impl From<PrekeyBundle> for Introduction {
+    fn from(value: PrekeyBundle) -> Self {
+        Introduction {
+            installation_key: value.identity_key,
+            ephemeral_key: value.signed_prekey,
+        }
+    }
+}
+
+impl Into<Vec<u8>> for Introduction {
+    fn into(self) -> Vec<u8> {
+        // TODO: avoid copies, via writing directly to slice
+        let link = format!(
+            "Bundle:{}:{}",
+            hex::encode(self.installation_key.as_bytes()),
+            hex::encode(self.ephemeral_key.as_bytes()),
+        );
+
+        link.into_bytes()
+    }
+}
+
+impl TryFrom<Vec<u8>> for Introduction {
+    type Error = ChatError;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        let str_value =
+            String::from_utf8(value).map_err(|_| ChatError::BadParsing("Introduction"))?;
+        let parts: Vec<&str> = str_value.splitn(3, ':').collect();
+
+        if parts[0] != "Bundle" {
+            return Err(ChatError::BadBundleValue(
+                "not recognized as an introduction bundle".into(),
+            ));
+        }
+
+        let installation_bytes: [u8; 32] = hex::decode(parts[1])
+            .map_err(|_| ChatError::BadParsing("installation_key"))?
+            .try_into()
+            .map_err(|_| ChatError::InvalidKeyLength)?;
+        let installation_key = PublicKey::from(installation_bytes);
+
+        let ephemeral_bytes: [u8; 32] = hex::decode(parts[1])
+            .map_err(|_| ChatError::BadParsing("ephemeral_key"))?
+            .try_into()
+            .map_err(|_| ChatError::InvalidKeyLength)?;
+        let ephemeral_key = PublicKey::from(ephemeral_bytes);
+
+        Ok(Introduction {
+            installation_key,
+            ephemeral_key,
+        })
+    }
+}


### PR DESCRIPTION
This PR adds a "Introduction Bundle" used to establish conversations with a remote participant. 

- This stops the internal type PreKeyBundle  from being exposed.
- Provides a placeholder implementation of Introductions (aka InviteLinks)
- Provides easy integration point for future implementation.

Also fixes a `todo` to make create_private_convo  return payloads.

This work is a is a precursor for #18