### PR TITLE
Remove unneeded traits and warnings

### DIFF
--- a/conversations/src/context.rs
+++ b/conversations/src/context.rs
@@ -22,7 +22,6 @@ pub struct Context {
     _identity: Rc<Identity>,
     store: ConversationStore,
     inbox: Inbox,
-    buf_size: usize,
     convo_handle_map: HashMap<u32, Arc<str>>,
     next_convo_handle: ConvoHandle,
 }
@@ -35,18 +34,9 @@ impl Context {
             _identity: identity,
             store: ConversationStore::new(),
             inbox,
-            buf_size: 0,
             convo_handle_map: HashMap::new(),
             next_convo_handle: INITIAL_CONVO_HANDLE,
         }
-    }
-
-    pub fn buffer_size(&self) -> usize {
-        self.buf_size
-    }
-
-    pub fn set_buffer_size(&mut self, size: usize) {
-        self.buf_size = size
     }
 
     pub fn create_private_convo(

--- a/conversations/src/crypto.rs
+++ b/conversations/src/crypto.rs
@@ -1,5 +1,3 @@
-pub use blake2::Digest;
-use blake2::{Blake2b, digest};
 use prost::bytes::Bytes;
 pub use x25519_dalek::{PublicKey, StaticSecret};
 
@@ -12,6 +10,3 @@ impl CopyBytes for PublicKey {
         Bytes::copy_from_slice(self.as_bytes())
     }
 }
-
-#[allow(dead_code)]
-pub type Blake2b128 = Blake2b<digest::consts::U16>;


### PR DESCRIPTION
This PR aims to clean up warnings in the workspace.

There currently are many warnings due to unfinished code-paths that result in an `unused` warnings.

Changes:
- Remove ConvoFactory trait - This is a premature optimization and not strictly needed. Removing for now.
- Remove Buffersize getters and setters. If needed for FFI it can be re-added.

The warnings which remain involve the inbound decryption path. These will be removed in the next PR which implements payload handling. 