### PR TITLE
Update content to use byte slice

### DIFF
--- a/conversations/src/api.rs
+++ b/conversations/src/api.rs
@@ -79,11 +79,8 @@ pub fn create_new_private_convo(
         };
     };
 
-    // Convert input content to String
-    let msg = String::from_utf8_lossy(&content).into_owned();
-
     // Create conversation
-    let (convo_handle, payloads) = ctx.0.create_private_convo(&intro, msg);
+    let (convo_handle, payloads) = ctx.0.create_private_convo(&intro, &content);
 
     // Convert payloads to FFI-compatible vector
     let ffi_payloads: Vec<Payload> = payloads

--- a/conversations/src/context.rs
+++ b/conversations/src/context.rs
@@ -52,7 +52,7 @@ impl Context {
     pub fn create_private_convo(
         &mut self,
         remote_bundle: &Introduction,
-        content: String,
+        content: &[u8],
     ) -> (ConvoHandle, Vec<AddressedEnvelope>) {
         let (convo, payloads) = self
             .inbox

--- a/conversations/src/inbox/inbox.rs
+++ b/conversations/src/inbox/inbox.rs
@@ -74,7 +74,7 @@ impl Inbox {
     pub fn invite_to_private_convo(
         &self,
         remote_bundle: &Introduction,
-        initial_message: String,
+        initial_message: &[u8],
     ) -> Result<(PrivateV1Convo, Vec<AddressedEncryptedPayload>), ChatError> {
         let mut rng = OsRng;
 
@@ -91,7 +91,7 @@ impl Inbox {
 
         let mut convo = PrivateV1Convo::new_initiator(seed_key, remote_bundle.ephemeral_key);
 
-        let mut payloads = convo.send_message(initial_message.as_bytes())?;
+        let mut payloads = convo.send_message(initial_message)?;
 
         // Wrap First payload in Invite
         if let Some(first_message) = payloads.get_mut(0) {
@@ -249,7 +249,7 @@ mod tests {
 
         let bundle = raya_inbox.create_bundle();
         let (_, payloads) = saro_inbox
-            .invite_to_private_convo(&bundle.into(), "hello".into())
+            .invite_to_private_convo(&bundle.into(), "hello".as_bytes())
             .unwrap();
 
         let payload = payloads

--- a/nim-bindings/examples/pingpong.nim
+++ b/nim-bindings/examples/pingpong.nim
@@ -1,7 +1,17 @@
 import options
 import results
+import std/strutils
 
 import ../src/libchat
+
+
+## Convert a string to seq[byte]
+proc encode*(s: string): seq[byte] =
+  if s.len == 0:
+    return @[]
+  result = newSeq[byte](s.len)
+  copyMem(addr result[0], unsafeAddr s[0], s.len)
+
 
 proc pingpong() =
 
@@ -13,7 +23,7 @@ proc pingpong() =
   let intro = raya.createIntroductionBundle().expect("[Raya] Couldn't create intro bundle")
   echo "Raya's Intro Bundle: ",intro
 
-  var (convo_sr, payloads) = saro.createNewPrivateConvo(intro, "Hey Raya").expect("[Saro] Couldn't create convo")
+  var (convo_sr, payloads) = saro.createNewPrivateConvo(intro, encode("Hey Raya")).expect("[Saro] Couldn't create convo")
   echo "ConvoHandle::  ", convo_sr
   echo "Payload::      ", payloads
 

--- a/nim-bindings/src/libchat.nim
+++ b/nim-bindings/src/libchat.nim
@@ -46,7 +46,7 @@ proc createIntroductionBundle*(ctx: LibChat): Result[string, string] =
   return ok(cast[string](buffer))
 
 ## Create a Private Convo
-proc createNewPrivateConvo*(ctx: LibChat, bundle: string, content: string): Result[(ConvoHandle, seq[PayloadResult]), string] =
+proc createNewPrivateConvo*(ctx: LibChat, bundle: string, content: seq[byte]): Result[(ConvoHandle, seq[PayloadResult]), string] =
   if ctx.handle == nil:
     return err("Context handle is nil")
 
@@ -83,7 +83,7 @@ proc createNewPrivateConvo*(ctx: LibChat, bundle: string, content: string): Resu
   return ok((convoId, payloads))
 
 ## Send content to an existing conversation
-proc sendContent*(ctx: LibChat, convoHandle: ConvoHandle, content: string): Result[seq[PayloadResult], string] =
+proc sendContent*(ctx: LibChat, convoHandle: ConvoHandle, content: seq[byte]): Result[seq[PayloadResult], string] =
   if ctx.handle == nil:
     return err("Context handle is nil")
 


### PR DESCRIPTION
Content was previously using `String` as its type for testing. 

This PR full removes String content and instead passes byte slices.  Byte slices reduce copies, and treat the content agnostically 