### PR TITLE
refactor: use new styling for conversations crate without mod.rs

### DIFF
--- a/core/conversations/src/api.rs
+++ b/core/conversations/src/api.rs
@@ -13,12 +13,9 @@ use safer_ffi::{
     prelude::{c_slice, repr_c},
 };
 
-use storage::StorageConfig;
-
 use crate::{
     context::{Context, Introduction},
     errors::ChatError,
-    ffi::utils::CResult,
     types::ContentData,
 };
 
@@ -55,41 +52,6 @@ pub struct ContextHandle(pub(crate) Context);
 pub fn create_context(name: repr_c::String) -> repr_c::Box<ContextHandle> {
     // Deference name to to `str` and then borrow to &str
     Box::new(ContextHandle(Context::new_with_name(&*name))).into()
-}
-
-/// Creates a new libchat Context with file-based persistent storage.
-///
-/// The identity will be loaded from storage if it exists, or created and saved if not.
-///
-/// # Parameters
-/// - name: Friendly name for the identity (used if creating new identity)
-/// - db_path: Path to the SQLite database file
-/// - db_secret: Secret key for encrypting the database
-///
-/// # Returns
-/// CResult with context handle on success, or error string on failure.
-/// On success, the context handle must be freed with `destroy_context()` after usage.
-/// On error, the error string must be freed with `destroy_string()` after usage.
-#[ffi_export]
-pub fn create_context_with_storage(
-    name: repr_c::String,
-    db_path: repr_c::String,
-    db_secret: repr_c::String,
-) -> CResult<repr_c::Box<ContextHandle>, repr_c::String> {
-    let config = StorageConfig::Encrypted {
-        path: db_path.to_string(),
-        key: db_secret.to_string(),
-    };
-    match Context::open(&*name, config) {
-        Ok(ctx) => CResult {
-            ok: Some(Box::new(ContextHandle(ctx)).into()),
-            err: None,
-        },
-        Err(e) => CResult {
-            ok: None,
-            err: Some(e.to_string().into()),
-        },
-    }
 }
 
 /// Returns the friendly name of the contexts installation.

--- a/core/conversations/src/ffi/mod.rs
+++ b/core/conversations/src/ffi/mod.rs
@@ -1,1 +1,0 @@
-pub mod utils;

--- a/core/conversations/src/ffi/utils.rs
+++ b/core/conversations/src/ffi/utils.rs
@@ -1,8 +1,0 @@
-use safer_ffi::prelude::*;
-
-#[derive_ReprC]
-#[repr(C)]
-pub struct CResult<T: ReprC, Err: ReprC> {
-    pub ok: Option<T>,
-    pub err: Option<Err>,
-}

--- a/core/conversations/src/lib.rs
+++ b/core/conversations/src/lib.rs
@@ -3,7 +3,6 @@ mod context;
 mod conversation;
 mod crypto;
 mod errors;
-mod ffi;
 mod identity;
 mod inbox;
 mod proto;

--- a/core/conversations/src/storage.rs
+++ b/core/conversations/src/storage.rs
@@ -1,11 +1,12 @@
 //! Chat-specific storage implementation.
 
+mod migrations;
+pub(crate) mod types;
+
 use storage::{RusqliteError, SqliteDb, StorageConfig, StorageError, params};
 use zeroize::Zeroize;
 
-use super::migrations;
-use super::types::IdentityRecord;
-use crate::identity::Identity;
+use crate::{identity::Identity, storage::types::IdentityRecord};
 
 /// Chat-specific storage operations.
 ///

--- a/core/conversations/src/storage.rs
+++ b/core/conversations/src/storage.rs
@@ -1,7 +1,7 @@
 //! Chat-specific storage implementation.
 
 mod migrations;
-pub(crate) mod types;
+mod types;
 
 use storage::{RusqliteError, SqliteDb, StorageConfig, StorageError, params};
 use zeroize::Zeroize;

--- a/core/conversations/src/storage/mod.rs
+++ b/core/conversations/src/storage/mod.rs
@@ -1,7 +1,0 @@
-//! Storage module for persisting chat state.
-
-mod db;
-mod migrations;
-pub(crate) mod types;
-
-pub(crate) use db::ChatStorage;


### PR DESCRIPTION
This is the follow up PR to clean the repo to use new module styling.

More context: https://github.com/logos-messaging/libchat/issues/68