### PR TITLE
Dependency cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,8 +278,8 @@ dependencies = [
  "arboard",
  "base64",
  "clap",
- "client",
  "crossterm 0.29.0",
+ "logos-chat",
  "ratatui",
  "serde",
  "serde_json",
@@ -360,22 +360,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "client"
-version = "0.1.0"
-dependencies = [
- "chat-sqlite",
- "components",
- "libchat",
- "tempfile",
- "thiserror",
-]
-
-[[package]]
 name = "client-ffi"
 version = "0.1.0"
 dependencies = [
- "client",
  "libchat",
+ "logos-chat",
  "safer-ffi",
 ]
 
@@ -1743,6 +1732,17 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "logos-chat"
+version = "0.1.0"
+dependencies = [
+ "chat-sqlite",
+ "components",
+ "libchat",
+ "tempfile",
+ "thiserror",
+]
 
 [[package]]
 name = "lru"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,10 @@ default-members = [
 [workspace.dependencies]
 # Internal Workspace dependency declarations (sorted)
 chat-sqlite = { path = "core/sqlite" }
-client = { path = "crates/client" }
 components = { path = "extensions/components" }
 crypto = { path = "core/crypto" }
 libchat = { path = "core/conversations" }
+logos-chat = { path = "crates/client" }
 storage = { path = "core/storage" }
 
 # External Workspace dependency declarations (sorted)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,15 +3,15 @@
 resolver = "3"
 
 members = [
-    "core/sqlite",
+    "bin/chat-cli",
     "core/conversations",
     "core/crypto",
     "core/double-ratchets",
-    "core/storage",
     "core/integration_tests_core",
-    "crates/client",
+    "core/sqlite",
+    "core/storage",
     "crates/client-ffi",
-    "bin/chat-cli",
+    "crates/client",
     "extensions/components",
 ]
 
@@ -27,12 +27,15 @@ default-members = [
 ]
 
 [workspace.dependencies]
-    blake2 = "0.10"
-    crypto = { path = "core/crypto" }
-    libchat = { path = "core/conversations" }
-    logoschat_components = {package="components", path ="extensions/components"} 
-    sqlite = { path = "core/sqlite"}
-    storage = { path = "core/storage" }
+# Internal Workspace dependency declarations (sorted)
+crypto = { path = "core/crypto" }
+libchat = { path = "core/conversations" }
+logoschat_components = {package = "components", path = "extensions/components"}
+sqlite = { path = "core/sqlite" }
+storage = { path = "core/storage" }
+
+# External Workspace dependency declarations (sorted)
+blake2 = "0.10"
 
 # Panicking across FFI boundaries is UB; abort is the correct strategy for a
 # C FFI library.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,13 @@ default-members = [
 
 [workspace.dependencies]
 # Internal Workspace dependency declarations (sorted)
+chat-sqlite = { path = "core/sqlite" }
+client = { path = "crates/client" }
+components = { path = "extensions/components" }
 crypto = { path = "core/crypto" }
 libchat = { path = "core/conversations" }
-logoschat_components = {package = "components", path = "extensions/components"}
-sqlite = { path = "core/sqlite" }
+logoschat_components = { package = "components", path = "extensions/components" } # TODO: Remove alias 
+sqlite = { package = "chat-sqlite", path = "core/sqlite" } # TODO: remove alias
 storage = { path = "core/storage" }
 
 # External Workspace dependency declarations (sorted)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,6 @@ client = { path = "crates/client" }
 components = { path = "extensions/components" }
 crypto = { path = "core/crypto" }
 libchat = { path = "core/conversations" }
-logoschat_components = { package = "components", path = "extensions/components" } # TODO: Remove alias 
-sqlite = { package = "chat-sqlite", path = "core/sqlite" } # TODO: remove alias
 storage = { path = "core/storage" }
 
 # External Workspace dependency declarations (sorted)

--- a/bin/chat-cli/Cargo.toml
+++ b/bin/chat-cli/Cargo.toml
@@ -9,13 +9,14 @@ path = "src/main.rs"
 
 [dependencies]
 # Workspace dependencies (sorted)
-client = { path = "../../crates/client" }
+client = { workspace = true }
 
 # External dependencies (sorted)
 anyhow = "1.0"
 arboard = "3"
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
+
 crossterm = "0.29"
 ratatui = "0.29"
 serde = { version = "1.0", features = ["derive"] }

--- a/bin/chat-cli/Cargo.toml
+++ b/bin/chat-cli/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Workspace dependencies (sorted)
-client = { workspace = true }
+logos-chat = { workspace = true }
 
 # External dependencies (sorted)
 anyhow = "1.0"

--- a/bin/chat-cli/Cargo.toml
+++ b/bin/chat-cli/Cargo.toml
@@ -8,16 +8,18 @@ name = "chat-cli"
 path = "src/main.rs"
 
 [dependencies]
-# Reference a specific commit so updates to the Core does not break examples
+# Workspace dependencies (sorted)
 client = { path = "../../crates/client" }
-ratatui = "0.29"
-crossterm = "0.29"
-clap = { version = "4", features = ["derive"] }
+
+# External dependencies (sorted)
 anyhow = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 arboard = "3"
 base64 = "0.22"
+clap = { version = "4", features = ["derive"] }
+crossterm = "0.29"
+ratatui = "0.29"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/bin/chat-cli/src/app.rs
+++ b/bin/chat-cli/src/app.rs
@@ -5,7 +5,7 @@ use std::sync::mpsc;
 
 use anyhow::Result;
 use arboard::Clipboard;
-use client::{ConversationIdOwned, DeliveryService};
+use logos_chat::{ConversationIdOwned, DeliveryService};
 use serde::{Deserialize, Serialize};
 
 use crate::utils::now;
@@ -42,7 +42,7 @@ pub struct AppState {
 }
 
 pub struct ChatApp<D: DeliveryService> {
-    pub client: client::ChatClient<D>,
+    pub client: logos_chat::ChatClient<D>,
     inbound: mpsc::Receiver<Vec<u8>>,
     pub state: AppState,
     /// Ephemeral command output — not persisted, cleared on chat switch.
@@ -55,7 +55,7 @@ pub struct ChatApp<D: DeliveryService> {
 
 impl<D: DeliveryService + 'static> ChatApp<D> {
     pub fn new(
-        client: client::ChatClient<D>,
+        client: logos_chat::ChatClient<D>,
         inbound: mpsc::Receiver<Vec<u8>>,
         user_name: &str,
         data_dir: &Path,

--- a/bin/chat-cli/src/app.rs
+++ b/bin/chat-cli/src/app.rs
@@ -5,7 +5,7 @@ use std::sync::mpsc;
 
 use anyhow::Result;
 use arboard::Clipboard;
-use logos_chat::{ConversationIdOwned, DeliveryService};
+use logos_chat::{ChatClient, ConversationIdOwned, DeliveryService};
 use serde::{Deserialize, Serialize};
 
 use crate::utils::now;
@@ -42,7 +42,7 @@ pub struct AppState {
 }
 
 pub struct ChatApp<D: DeliveryService> {
-    pub client: logos_chat::ChatClient<D>,
+    pub client: ChatClient<D>,
     inbound: mpsc::Receiver<Vec<u8>>,
     pub state: AppState,
     /// Ephemeral command output — not persisted, cleared on chat switch.
@@ -55,7 +55,7 @@ pub struct ChatApp<D: DeliveryService> {
 
 impl<D: DeliveryService + 'static> ChatApp<D> {
     pub fn new(
-        client: logos_chat::ChatClient<D>,
+        client: ChatClient<D>,
         inbound: mpsc::Receiver<Vec<u8>>,
         user_name: &str,
         data_dir: &Path,

--- a/bin/chat-cli/src/main.rs
+++ b/bin/chat-cli/src/main.rs
@@ -8,7 +8,7 @@ use std::sync::mpsc;
 
 use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
-use client::DeliveryService;
+use logos_chat::DeliveryService;
 
 use app::ChatApp;
 
@@ -105,9 +105,9 @@ fn run<D: DeliveryService + 'static>(
         .context("db path contains non-UTF-8 characters")?
         .to_string();
 
-    let client = client::ChatClient::open(
+    let client = logos_chat::ChatClient::open(
         cli.name.clone(),
-        client::StorageConfig::Encrypted {
+        logos_chat::StorageConfig::Encrypted {
             path: db_str,
             key: "chat-cli".to_string(),
         },
@@ -160,9 +160,9 @@ fn run_logos_delivery(cli: Cli) -> Result<()> {
                     .to_str()
                     .context("db path contains non-UTF-8 characters")?
                     .to_string();
-                client::ChatClient::open(
+                logos_chat::ChatClient::open(
                     cli.name.clone(),
-                    client::StorageConfig::Encrypted {
+                    logos_chat::StorageConfig::Encrypted {
                         path: db_str,
                         key: "chat-cli".to_string(),
                     },
@@ -171,7 +171,7 @@ fn run_logos_delivery(cli: Cli) -> Result<()> {
                 .map_err(|e| anyhow::anyhow!("{e:?}"))
                 .context("failed to open persistent client")?
             }
-            None => client::ChatClient::new(cli.name.clone(), delivery),
+            None => logos_chat::ChatClient::new(cli.name.clone(), delivery),
         };
 
         let mut app = ChatApp::new(client, inbound, &cli.name, &data_dir)?;

--- a/bin/chat-cli/src/transport/file.rs
+++ b/bin/chat-cli/src/transport/file.rs
@@ -6,7 +6,7 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use client::{AddressedEnvelope, DeliveryService};
+use logos_chat::{AddressedEnvelope, DeliveryService};
 
 #[derive(Debug, thiserror::Error)]
 pub enum FileTransportError {

--- a/bin/chat-cli/src/transport/logos_delivery.rs
+++ b/bin/chat-cli/src/transport/logos_delivery.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
-use client::{AddressedEnvelope, DeliveryService};
+use logos_chat::{AddressedEnvelope, DeliveryService};
 use tracing::{error, info, warn};
 
 use wrapper::LogosNodeCtx;

--- a/bin/chat-cli/src/ui.rs
+++ b/bin/chat-cli/src/ui.rs
@@ -16,7 +16,7 @@ use ratatui::{
     widgets::{Block, Borders, List, ListItem, Paragraph, Wrap},
 };
 
-use client::DeliveryService;
+use logos_chat::DeliveryService;
 
 use crate::app::ChatApp;
 

--- a/core/conversations/Cargo.toml
+++ b/core/conversations/Cargo.toml
@@ -9,11 +9,13 @@ crate-type = ["rlib","staticlib"]
 [dependencies]
 # Workspace dependencies (sorted)
 blake2 = { workspace = true }
+crypto = { workspace = true }
+sqlite = { workspace = true }
+storage = { workspace = true }
 
 # External dependencies (sorted)
 base64 = "0.22"
 chat-proto = { git = "https://github.com/logos-messaging/chat_proto" }
-crypto = { path = "../crypto" }
 double-ratchets = { path = "../double-ratchets" }
 hex = "0.4.3"
 openmls = { version = "0.8.1", features = ["libcrux-provider"] }
@@ -22,12 +24,12 @@ openmls_traits = "0.5.0"
 prost = "0.14.1"
 rand_core = { version = "0.6" }
 safer-ffi = "0.1.13"
-sqlite = { package = "chat-sqlite", path = "../sqlite" }
-storage = { path = "../storage" }
 thiserror = "2.0.17"
 x25519-dalek = { version = "2.0.1", features = ["static_secrets", "reusable_secrets", "getrandom"] }
 
 [dev-dependencies]
+# Workspace dependencies (sorted)
+components = { workspace = true }
+
 # External dependencies (sorted)
-components = { package = "components", path = "../../extensions/components" }
 tempfile = "3"

--- a/core/conversations/Cargo.toml
+++ b/core/conversations/Cargo.toml
@@ -7,23 +7,27 @@ edition = "2024"
 crate-type = ["rlib","staticlib"]
 
 [dependencies]
+# Workspace dependencies (sorted)
+blake2 = { workspace = true }
+
+# External dependencies (sorted)
 base64 = "0.22"
-sqlite = { package = "chat-sqlite", path = "../sqlite" }
-blake2.workspace = true
 chat-proto = { git = "https://github.com/logos-messaging/chat_proto" }
 crypto = { path = "../crypto" }
 double-ratchets = { path = "../double-ratchets" }
 hex = "0.4.3"
-prost = "0.14.1"
-rand_core = { version = "0.6" }
-safer-ffi = "0.1.13"
-thiserror = "2.0.17"
-x25519-dalek = { version = "2.0.1", features = ["static_secrets", "reusable_secrets", "getrandom"] }
-storage = { path = "../storage" }
 openmls = { version = "0.8.1", features = ["libcrux-provider"] }
 openmls_libcrux_crypto = "0.3.1"
 openmls_traits = "0.5.0"
+prost = "0.14.1"
+rand_core = { version = "0.6" }
+safer-ffi = "0.1.13"
+sqlite = { package = "chat-sqlite", path = "../sqlite" }
+storage = { path = "../storage" }
+thiserror = "2.0.17"
+x25519-dalek = { version = "2.0.1", features = ["static_secrets", "reusable_secrets", "getrandom"] }
 
 [dev-dependencies]
+# External dependencies (sorted)
 components = { package = "components", path = "../../extensions/components" }
 tempfile = "3"

--- a/core/conversations/Cargo.toml
+++ b/core/conversations/Cargo.toml
@@ -9,8 +9,8 @@ crate-type = ["rlib","staticlib"]
 [dependencies]
 # Workspace dependencies (sorted)
 blake2 = { workspace = true }
+chat-sqlite = { workspace = true }
 crypto = { workspace = true }
-sqlite = { workspace = true }
 storage = { workspace = true }
 
 # External dependencies (sorted)

--- a/core/conversations/src/conversation/privatev1.rs
+++ b/core/conversations/src/conversation/privatev1.rs
@@ -281,8 +281,8 @@ impl<S: ConversationStore + RatchetStore> Debug for PrivateV1Convo<S> {
 
 #[cfg(test)]
 mod tests {
+    use chat_sqlite::{ChatStorage, StorageConfig};
     use crypto::PrivateKey;
-    use sqlite::{ChatStorage, StorageConfig};
 
     use super::*;
 

--- a/core/conversations/src/inbox/handler.rs
+++ b/core/conversations/src/inbox/handler.rs
@@ -260,7 +260,7 @@ mod tests {
     use std::cell::RefCell;
 
     use super::*;
-    use sqlite::{ChatStorage, StorageConfig};
+    use chat_sqlite::{ChatStorage, StorageConfig};
 
     #[test]
     fn test_invite_privatev1_roundtrip() {

--- a/core/conversations/src/lib.rs
+++ b/core/conversations/src/lib.rs
@@ -11,11 +11,11 @@ mod types;
 mod utils;
 
 pub use account::LogosAccount;
+pub use chat_sqlite::ChatStorage;
+pub use chat_sqlite::StorageConfig;
 pub use context::{Context, ConversationId, ConversationIdOwned, Introduction};
 pub use conversation::GroupConvo;
 pub use errors::ChatError;
 pub use service_traits::{DeliveryService, RegistrationService};
-pub use sqlite::ChatStorage;
-pub use sqlite::StorageConfig;
 pub use types::{AccountId, AddressedEnvelope, ContentData};
 pub use utils::hex_trunc;

--- a/core/crypto/Cargo.toml
+++ b/core/crypto/Cargo.toml
@@ -4,12 +4,13 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-x25519-dalek = { version = "2.0.1", features = ["static_secrets"] }
-hkdf = "0.12"
-sha2 = "0.10"
-rand_core = { version = "0.6", features = ["getrandom"] }
+# External dependencies (sorted)
 ed25519-dalek = { version = "2.2.0", features = ["rand_core"] }
-xeddsa = "1.0.2"
-zeroize = {version = "1.8.2", features= ["derive"]}
 generic-array = "1.3.5"
+hkdf = "0.12"
+rand_core = { version = "0.6", features = ["getrandom"] }
+sha2 = "0.10"
 thiserror = "2"
+x25519-dalek = { version = "2.0.1", features = ["static_secrets"] }
+xeddsa = "1.0.2"
+zeroize = { version = "1.8.2", features = ["derive"] }

--- a/core/double-ratchets/Cargo.toml
+++ b/core/double-ratchets/Cargo.toml
@@ -22,6 +22,8 @@ x25519-dalek = { version = "2.0.1", features = ["static_secrets"] }
 zeroize = "1.8.2"
 
 [dev-dependencies]
+# Workspace dependencies (sorted)
+sqlite = { workspace = true }
+
 # External dependencies (sorted)
-sqlite = { package = "chat-sqlite", path = "../sqlite" }
 tempfile = "3"

--- a/core/double-ratchets/Cargo.toml
+++ b/core/double-ratchets/Cargo.toml
@@ -23,7 +23,7 @@ zeroize = "1.8.2"
 
 [dev-dependencies]
 # Workspace dependencies (sorted)
-sqlite = { workspace = true }
+chat-sqlite = { workspace = true }
 
 # External dependencies (sorted)
 tempfile = "3"

--- a/core/double-ratchets/Cargo.toml
+++ b/core/double-ratchets/Cargo.toml
@@ -7,17 +7,21 @@ edition = "2024"
 crate-type = ["rlib", "cdylib"]
 
 [dependencies]
-x25519-dalek = { version="2.0.1", features=["static_secrets"] }
-chacha20poly1305 = "0.10.1"
-rand_core = "0.6.4"
-rand = "0.9.3"
-hkdf = "0.12.4"
-thiserror = "2"
-blake2 = "0.10.6"
-zeroize = "1.8.2"
+# Workspace dependencies (sorted)
 storage = { workspace = true }
+
+# External dependencies (sorted)
+blake2 = "0.10.6"
+chacha20poly1305 = "0.10.1"
+hkdf = "0.12.4"
+rand = "0.9.3"
+rand_core = "0.6.4"
 serde = "1.0"
+thiserror = "2"
+x25519-dalek = { version = "2.0.1", features = ["static_secrets"] }
+zeroize = "1.8.2"
 
 [dev-dependencies]
+# External dependencies (sorted)
 sqlite = { package = "chat-sqlite", path = "../sqlite" }
 tempfile = "3"

--- a/core/double-ratchets/examples/out_of_order_demo.rs
+++ b/core/double-ratchets/examples/out_of_order_demo.rs
@@ -2,8 +2,8 @@
 //!
 //! Run with: cargo run --example out_of_order_demo -p double-ratchets
 
+use chat_sqlite::{ChatStorage, StorageConfig};
 use double_ratchets::{InstallationKeyPair, RatchetSession};
-use sqlite::{ChatStorage, StorageConfig};
 use tempfile::NamedTempFile;
 
 fn main() {

--- a/core/double-ratchets/examples/storage_demo.rs
+++ b/core/double-ratchets/examples/storage_demo.rs
@@ -2,8 +2,8 @@
 //!
 //! Run with: cargo run --example storage_demo -p double-ratchets
 
+use chat_sqlite::{ChatStorage, StorageConfig};
 use double_ratchets::{InstallationKeyPair, RatchetSession};
-use sqlite::{ChatStorage, StorageConfig};
 use tempfile::NamedTempFile;
 
 fn main() {

--- a/core/double-ratchets/src/storage/session.rs
+++ b/core/double-ratchets/src/storage/session.rs
@@ -168,7 +168,7 @@ fn save_state<S: RatchetStore, D: HkdfInfo>(
 mod tests {
     use super::*;
     use crate::hkdf::DefaultDomain;
-    use sqlite::ChatStorage;
+    use chat_sqlite::ChatStorage;
 
     fn create_test_storage() -> ChatStorage {
         ChatStorage::in_memory()

--- a/core/integration_tests_core/Cargo.toml
+++ b/core/integration_tests_core/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2024"
 # Workspace dependencies (sorted)
 components = { workspace = true }
 libchat = { workspace = true }
-sqlite = { workspace = true }
+chat-sqlite = { workspace = true }
 storage = { workspace = true }
 
 # External dependencies (sorted)

--- a/core/integration_tests_core/Cargo.toml
+++ b/core/integration_tests_core/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2024"
 
 [dev-dependencies]
 # Workspace dependencies (sorted)
+components = { workspace = true }
 libchat = { workspace = true }
+sqlite = { workspace = true }
 storage = { workspace = true }
 
 # External dependencies (sorted)
-components = { path = "../../extensions/components" }
-sqlite = { package = "chat-sqlite", path = "../sqlite" }
 tempfile = "3"

--- a/core/integration_tests_core/Cargo.toml
+++ b/core/integration_tests_core/Cargo.toml
@@ -7,9 +7,11 @@ edition = "2024"
 # name = "integration_tests_core"
 
 [dev-dependencies]
+# Workspace dependencies (sorted)
 libchat = { workspace = true }
 storage = { workspace = true }
-sqlite = {package = "chat-sqlite", path ="../sqlite"}
 
+# External dependencies (sorted)
 components = { path = "../../extensions/components" }
+sqlite = { package = "chat-sqlite", path = "../sqlite" }
 tempfile = "3"

--- a/core/integration_tests_core/tests/private_integration.rs
+++ b/core/integration_tests_core/tests/private_integration.rs
@@ -1,5 +1,5 @@
+use chat_sqlite::{ChatStorage, StorageConfig};
 use libchat::{Context, Introduction};
-use sqlite::{ChatStorage, StorageConfig};
 use storage::{ConversationStore, IdentityStore};
 use tempfile::tempdir;
 

--- a/core/sqlite/Cargo.toml
+++ b/core/sqlite/Cargo.toml
@@ -5,11 +5,13 @@ edition = "2024"
 description = "SQLite storage implementation for libchat"
 
 [dependencies]
+# Workspace dependencies (sorted)
+crypto = { workspace = true }
+storage = { workspace = true }
+
 # External dependencies (sorted)
-crypto = { path = "../crypto" }
 hex = "0.4.3"
 rusqlite = { version = "0.35", features = ["bundled-sqlcipher-vendored-openssl"] }
-storage = { path = "../storage" }
 zeroize = { version = "1.8.2", features = ["derive"] }
 
 [dev-dependencies]

--- a/core/sqlite/Cargo.toml
+++ b/core/sqlite/Cargo.toml
@@ -5,11 +5,13 @@ edition = "2024"
 description = "SQLite storage implementation for libchat"
 
 [dependencies]
+# External dependencies (sorted)
 crypto = { path = "../crypto" }
 hex = "0.4.3"
+rusqlite = { version = "0.35", features = ["bundled-sqlcipher-vendored-openssl"] }
 storage = { path = "../storage" }
 zeroize = { version = "1.8.2", features = ["derive"] }
-rusqlite = { version = "0.35", features = ["bundled-sqlcipher-vendored-openssl"] }
 
 [dev-dependencies]
+# External dependencies (sorted)
 tempfile = "3"

--- a/core/storage/Cargo.toml
+++ b/core/storage/Cargo.toml
@@ -5,5 +5,6 @@ edition = "2024"
 description = "Shared storage layer for libchat"
 
 [dependencies]
+# External dependencies (sorted)
 crypto = { path = "../crypto" }
 thiserror = "2"

--- a/core/storage/Cargo.toml
+++ b/core/storage/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2024"
 description = "Shared storage layer for libchat"
 
 [dependencies]
+# Workspace dependencies (sorted)
+crypto = { workspace = true }
+
 # External dependencies (sorted)
-crypto = { path = "../crypto" }
 thiserror = "2"

--- a/crates/client-ffi/Cargo.toml
+++ b/crates/client-ffi/Cargo.toml
@@ -11,9 +11,12 @@ name = "generate-headers"
 required-features = ["headers"]
 
 [dependencies]
-safer-ffi = "0.1.13"
-client  = { path = "../client" }
+# Workspace dependencies (sorted)
 libchat = { workspace = true }
+
+# External dependencies (sorted)
+client = { path = "../client" }
+safer-ffi = "0.1.13"
 
 [features]
 headers = ["safer-ffi/headers"]

--- a/crates/client-ffi/Cargo.toml
+++ b/crates/client-ffi/Cargo.toml
@@ -12,10 +12,10 @@ required-features = ["headers"]
 
 [dependencies]
 # Workspace dependencies (sorted)
+client = { workspace = true }
 libchat = { workspace = true }
 
 # External dependencies (sorted)
-client = { path = "../client" }
 safer-ffi = "0.1.13"
 
 [features]

--- a/crates/client-ffi/Cargo.toml
+++ b/crates/client-ffi/Cargo.toml
@@ -12,8 +12,8 @@ required-features = ["headers"]
 
 [dependencies]
 # Workspace dependencies (sorted)
-client = { workspace = true }
 libchat = { workspace = true }
+logos-chat = { workspace = true }
 
 # External dependencies (sorted)
 safer-ffi = "0.1.13"

--- a/crates/client-ffi/src/api.rs
+++ b/crates/client-ffi/src/api.rs
@@ -2,7 +2,7 @@ use safer_ffi::prelude::*;
 use std::sync::Arc;
 
 use crate::delivery::{CDelivery, DeliverFn};
-use client::{ChatClient, ClientError};
+use logos_chat::{ChatClient, ClientError};
 
 // ---------------------------------------------------------------------------
 // Opaque client handle
@@ -205,7 +205,7 @@ fn client_send_message(
         Ok(s) => s,
         Err(_) => return ErrorCode::BadUtf8,
     };
-    let convo_id_owned: client::ConversationIdOwned = Arc::from(id_str);
+    let convo_id_owned: logos_chat::ConversationIdOwned = Arc::from(id_str);
     match handle.0.send_message(&convo_id_owned, content.as_slice()) {
         Ok(()) => ErrorCode::None,
         Err(ClientError::Delivery(_)) => ErrorCode::DeliveryFail,

--- a/crates/client-ffi/src/delivery.rs
+++ b/crates/client-ffi/src/delivery.rs
@@ -1,5 +1,5 @@
-use client::DeliveryService;
 use libchat::AddressedEnvelope;
+use logos_chat::DeliveryService;
 
 /// C callback invoked for each outbound envelope. Return 0 or positive on success, negative on
 /// error. `addr_ptr/addr_len` is the delivery address; `data_ptr/data_len` is the encrypted

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "client"
+name = "logos-chat"
 version = "0.1.0"
 edition = "2024"
 

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -8,11 +8,11 @@ crate-type = ["rlib"]
 
 [dependencies]
 # Workspace dependencies (sorted)
+chat-sqlite = { workspace = true }
 libchat = { workspace = true }
 logoschat_components = { workspace = true} 
 
 # External dependencies (sorted)
-chat-sqlite = { path = "../../core/sqlite" }
 thiserror = "2"
 
 [dev-dependencies]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -9,8 +9,8 @@ crate-type = ["rlib"]
 [dependencies]
 # Workspace dependencies (sorted)
 chat-sqlite = { workspace = true }
+components = { workspace = true} 
 libchat = { workspace = true }
-logoschat_components = { workspace = true} 
 
 # External dependencies (sorted)
 thiserror = "2"

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -7,10 +7,14 @@ edition = "2024"
 crate-type = ["rlib"]
 
 [dependencies]
+# Workspace dependencies (sorted)
 libchat = { workspace = true }
 logoschat_components = { workspace = true} 
+
+# External dependencies (sorted)
 chat-sqlite = { path = "../../core/sqlite" }
 thiserror = "2"
 
 [dev-dependencies]
+# External dependencies (sorted)
 tempfile = "3"

--- a/crates/client/examples/message-exchange/main.rs
+++ b/crates/client/examples/message-exchange/main.rs
@@ -1,4 +1,4 @@
-use client::{ChatClient, ConversationIdOwned, InProcessDelivery};
+use logos_chat::{ChatClient, ConversationIdOwned, InProcessDelivery};
 use std::sync::Arc;
 
 fn main() {

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -3,7 +3,7 @@ use libchat::{
     DeliveryService, Introduction, StorageConfig,
 };
 
-use logoschat_components::EphemeralRegistry;
+use components::EphemeralRegistry;
 
 use crate::errors::ClientError;
 

--- a/crates/client/tests/saro_and_raya.rs
+++ b/crates/client/tests/saro_and_raya.rs
@@ -1,4 +1,4 @@
-use client::{
+use logos_chat::{
     ChatClient, ContentData, ConversationIdOwned, Cursor, InProcessDelivery, StorageConfig,
 };
 use std::sync::Arc;

--- a/extensions/components/Cargo.toml
+++ b/extensions/components/Cargo.toml
@@ -4,8 +4,10 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+# Workspace dependencies (sorted)
+crypto = { workspace = true }   # Needed because Storage traits require "Identity" struct
 libchat = { workspace = true }
 storage = { workspace = true }
-crypto = { workspace = true }   # Needed because Storage traits require "Identity" struct
 
+# External dependencies (sorted)
 hex = "0.4.3"


### PR DESCRIPTION
This PR standardizes cargo dependencies across the different crates. The lack of standardization was leading to merge conflicts and difficulty in tracing through the codebase. 

- Workspace crates which are used in more than one location are added as workspace dependencies 
- Dependencies are sorted, to minimize conflicts in future PRs
- sqlite, and components updated to use their package name rather than an alias 
- client crate renamed to `logos-chat` to clarify that it is the top level entry point for developers, and to reduce conflicts in developer applications