### PR TITLE
Remove naming conflict with Signatures

### DIFF
--- a/core/conversations/src/inbox/handshake.rs
+++ b/core/conversations/src/inbox/handshake.rs
@@ -97,7 +97,7 @@ mod tests {
         let bob_bundle = PrekeyBundle {
             identity_key: PublicKey::from(&bob_identity),
             signed_prekey: bob_signed_prekey_pub,
-            signature: crypto::Ed25519Signature([0u8; 64]),
+            signature: crypto::XedDsaSignature([0u8; 64]),
             onetime_prekey: None,
         };
 

--- a/core/conversations/src/inbox/introduction.rs
+++ b/core/conversations/src/inbox/introduction.rs
@@ -1,6 +1,6 @@
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use chat_proto::logoschat::intro::IntroBundle;
-use crypto::{Ed25519Signature, PrivateKey, PublicKey};
+use crypto::{PrivateKey, PublicKey, XedDsaSignature};
 use prost::Message;
 use rand_core::{CryptoRng, RngCore};
 
@@ -19,7 +19,7 @@ pub(crate) fn sign_intro_binding<R: RngCore + CryptoRng>(
     secret: &PrivateKey,
     ephemeral: &PublicKey,
     rng: R,
-) -> Ed25519Signature {
+) -> XedDsaSignature {
     let message = intro_binding_message(ephemeral);
     crypto::xeddsa_sign(secret, &message, rng)
 }
@@ -27,7 +27,7 @@ pub(crate) fn sign_intro_binding<R: RngCore + CryptoRng>(
 pub(crate) fn verify_intro_binding(
     pubkey: &PublicKey,
     ephemeral: &PublicKey,
-    signature: &Ed25519Signature,
+    signature: &XedDsaSignature,
 ) -> Result<(), crypto::SignatureError> {
     let message = intro_binding_message(ephemeral);
     crypto::xeddsa_verify(pubkey, &message, signature)
@@ -37,7 +37,7 @@ pub(crate) fn verify_intro_binding(
 pub struct Introduction {
     installation_key: PublicKey,
     ephemeral_key: PublicKey,
-    signature: Ed25519Signature,
+    signature: XedDsaSignature,
 }
 
 impl Introduction {
@@ -64,7 +64,7 @@ impl Introduction {
         &self.ephemeral_key
     }
 
-    pub fn signature(&self) -> &Ed25519Signature {
+    pub fn signature(&self) -> &XedDsaSignature {
         &self.signature
     }
 }
@@ -127,7 +127,7 @@ impl TryFrom<&[u8]> for Introduction {
 
         let installation_key = PublicKey::from(installation_bytes);
         let ephemeral_key = PublicKey::from(ephemeral_bytes);
-        let signature = Ed25519Signature(signature_bytes);
+        let signature = XedDsaSignature::from(signature_bytes);
 
         verify_intro_binding(&installation_key, &ephemeral_key, &signature)
             .map_err(|_| ChatError::BadBundleValue("invalid signature".into()))?;

--- a/core/crypto/src/lib.rs
+++ b/core/crypto/src/lib.rs
@@ -6,6 +6,6 @@ mod xeddsa_sign;
 
 pub use identity::Identity;
 pub use keys::{PrivateKey, PublicKey, SymmetricKey32};
-pub use signatures::{Ed25519SigningKey, Ed25519VerifyingKey};
+pub use signatures::{Ed25519Signature, Ed25519SigningKey, Ed25519VerifyingKey};
 pub use x3dh::{DomainSeparator, PrekeyBundle, X3Handshake};
-pub use xeddsa_sign::{Ed25519Signature, SignatureError, xeddsa_sign, xeddsa_verify};
+pub use xeddsa_sign::{SignatureError, XedDsaSignature, xeddsa_sign, xeddsa_verify};

--- a/core/crypto/src/x3dh.rs
+++ b/core/crypto/src/x3dh.rs
@@ -5,14 +5,14 @@ use rand_core::{CryptoRng, RngCore};
 use sha2::Sha256;
 
 use crate::keys::{PrivateKey, PublicKey, SymmetricKey32};
-use crate::xeddsa_sign::Ed25519Signature;
+use crate::xeddsa_sign::XedDsaSignature;
 
 /// A prekey bundle containing the public keys needed to initiate an X3DH key exchange.
 #[derive(Clone, Debug)]
 pub struct PrekeyBundle {
     pub identity_key: PublicKey,
     pub signed_prekey: PublicKey,
-    pub signature: Ed25519Signature,
+    pub signature: XedDsaSignature,
     pub onetime_prekey: Option<PublicKey>,
 }
 
@@ -151,7 +151,7 @@ mod tests {
         let bob_bundle = PrekeyBundle {
             identity_key: bob_identity_pub,
             signed_prekey: bob_signed_prekey_pub,
-            signature: Ed25519Signature::empty(),
+            signature: XedDsaSignature::empty(),
             onetime_prekey: Some(bob_onetime_prekey_pub),
         };
 
@@ -191,7 +191,7 @@ mod tests {
         let bob_bundle = PrekeyBundle {
             identity_key: bob_identity_pub,
             signed_prekey: bob_signed_prekey_pub,
-            signature: Ed25519Signature::empty(),
+            signature: XedDsaSignature::empty(),
             onetime_prekey: None,
         };
 

--- a/core/crypto/src/xeddsa_sign.rs
+++ b/core/crypto/src/xeddsa_sign.rs
@@ -9,21 +9,21 @@ use xeddsa::{Sign, Verify, xed25519};
 use crate::{PrivateKey, PublicKey};
 /// A 64-byte XEdDSA signature over an Ed25519-compatible curve.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Ed25519Signature(pub [u8; 64]);
+pub struct XedDsaSignature(pub [u8; 64]);
 
-impl Ed25519Signature {
+impl XedDsaSignature {
     pub fn empty() -> Self {
         Self([0u8; 64])
     }
 }
 
-impl AsRef<[u8; 64]> for Ed25519Signature {
+impl AsRef<[u8; 64]> for XedDsaSignature {
     fn as_ref(&self) -> &[u8; 64] {
         &self.0
     }
 }
 
-impl From<[u8; 64]> for Ed25519Signature {
+impl From<[u8; 64]> for XedDsaSignature {
     fn from(bytes: [u8; 64]) -> Self {
         Self(bytes)
     }
@@ -47,9 +47,9 @@ pub fn xeddsa_sign<R: RngCore + CryptoRng>(
     secret: &PrivateKey,
     message: &[u8],
     mut rng: R,
-) -> Ed25519Signature {
+) -> XedDsaSignature {
     let signing_key = xed25519::PrivateKey::from(secret);
-    Ed25519Signature(signing_key.sign(message, &mut rng))
+    XedDsaSignature(signing_key.sign(message, &mut rng))
 }
 
 /// Verify an XEdDSA signature using an X25519 public key.
@@ -64,7 +64,7 @@ pub fn xeddsa_sign<R: RngCore + CryptoRng>(
 pub fn xeddsa_verify(
     pubkey: &PublicKey,
     message: &[u8],
-    signature: &Ed25519Signature,
+    signature: &XedDsaSignature,
 ) -> Result<(), SignatureError> {
     let verify_key = xed25519::PublicKey::from(pubkey);
     verify_key


### PR DESCRIPTION
There is a naming conflict that exists in core/crypto. XedDsa and Ed25519 both return different objects named `Ed25519Signature`. This causes headaches in applications where the types need to be fully qualified to avoid errors; 

This PR renames the the XedDsa return type to `XedDsaSignature`; This:
- Avoids the name conflict on import
- More accurately reflects the type being returned. While the Two signature types are byte compatible, they are inherently different types, and ought not be used interchangeably. This fix maintains type isolation between the two different signature schemes. 