### PR TITLE
Add crate logos-accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,6 +1734,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "logos-account"
+version = "0.1.0"
+dependencies = [
+ "crypto",
+ "libchat",
+]
+
+[[package]]
 name = "logos-chat"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "3"
 
 members = [
     "bin/chat-cli",
+    "core/account",
     "core/conversations",
     "core/crypto",
     "core/double-ratchets",
@@ -16,14 +17,15 @@ members = [
 ]
 
 default-members = [
-    "core/sqlite",
+    "core/account",
     "core/conversations",
     "core/crypto",
     "core/double-ratchets",
-    "core/storage",
     "core/integration_tests_core",
-    "crates/client",
+    "core/sqlite",
+    "core/storage",
     "crates/client-ffi",
+    "crates/client",
 ]
 
 [workspace.dependencies]

--- a/core/account/Cargo.toml
+++ b/core/account/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "logos-account"
+version = "0.1.0"
+edition = "2024"
+
+[features]
+dev = []
+
+[dependencies]
+# Workspace dependencies (sorted)
+crypto = { workspace = true }
+libchat = { workspace = true }
+
+# External dependencies (sorted)

--- a/core/account/README.md
+++ b/core/account/README.md
@@ -1,0 +1,23 @@
+# λAccount
+
+Logos(λ) Accounts are used to represent users across multiple services. 
+
+An Account is a grouping of different entities used to describe a single User or entity in the Logos Ecosystem. 
+
+
+## Services Supported
+
+|Service | Supported |
+|--------|-----------|
+| [λChat](https://github.com/logos-messaging/logos-chat) | 🟢 |
+
+### `LogosAccount`
+
+Not Implemented
+
+### `TestLogosAccount` (`feature = "dev"`)
+
+A minimal implementation intended for development, testing, and CLI tooling. It accepts any string as the account ID and generates a fresh Ed25519 key pair on construction. State is not persisted — identity is lost on drop.
+
+**Do not use in production.**
+

--- a/core/account/src/account.rs
+++ b/core/account/src/account.rs
@@ -1,0 +1,42 @@
+use crypto::{Ed25519SigningKey, Ed25519VerifyingKey};
+
+use libchat::{AccountId, IdentityProvider};
+
+/// A Test Focused LogosAccount using a pre-defined identifier.
+/// The test account is not persisted, and uses a single user provided id.
+/// This account type should not be used in a production system.
+pub struct TestLogosAccount {
+    id: AccountId,
+    signing_key: Ed25519SigningKey,
+    verifying_key: Ed25519VerifyingKey,
+}
+
+impl TestLogosAccount {
+    pub fn new(explicit_id: impl Into<String>) -> Self {
+        let signing_key = Ed25519SigningKey::generate();
+        let verifying_key = signing_key.verifying_key();
+        Self {
+            id: AccountId::new(explicit_id.into()),
+            signing_key,
+            verifying_key,
+        }
+    }
+}
+
+impl IdentityProvider for TestLogosAccount {
+    fn account_id(&self) -> &AccountId {
+        &self.id
+    }
+
+    fn display_name(&self) -> String {
+        self.id.to_string()
+    }
+
+    fn public_key(&self) -> &Ed25519VerifyingKey {
+        &self.verifying_key
+    }
+
+    fn sign(&self, payload: &[u8]) -> crypto::Ed25519Signature {
+        self.signing_key.sign(payload)
+    }
+}

--- a/core/account/src/lib.rs
+++ b/core/account/src/lib.rs
@@ -1,0 +1,5 @@
+#[cfg(feature = "dev")]
+mod account;
+
+#[cfg(feature = "dev")]
+pub use account::TestLogosAccount;

--- a/core/conversations/src/lib.rs
+++ b/core/conversations/src/lib.rs
@@ -16,6 +16,6 @@ pub use chat_sqlite::StorageConfig;
 pub use context::{Context, ConversationId, ConversationIdOwned, Introduction};
 pub use conversation::GroupConvo;
 pub use errors::ChatError;
-pub use service_traits::{DeliveryService, RegistrationService};
+pub use service_traits::{DeliveryService, IdentityProvider, RegistrationService};
 pub use types::{AccountId, AddressedEnvelope, ContentData};
 pub use utils::hex_trunc;

--- a/core/conversations/src/service_traits.rs
+++ b/core/conversations/src/service_traits.rs
@@ -3,6 +3,8 @@
 /// different implementations.
 use std::{fmt::Debug, fmt::Display};
 
+use crypto::{Ed25519Signature, Ed25519VerifyingKey};
+
 use crate::types::{AccountId, AddressedEnvelope};
 
 /// A Delivery service is responsible for payload transport.
@@ -38,4 +40,15 @@ impl<T: RegistrationService> KeyPackageProvider for T {
     fn retrieve(&self, identity: &AccountId) -> Result<Option<Vec<u8>>, Self::Error> {
         RegistrationService::retrieve(self, identity)
     }
+}
+
+/// Represents an external Identity
+/// Implement this to provide an Authentication model for users/installations
+pub trait IdentityProvider {
+    fn account_id(&self) -> &AccountId;
+    // Display name is not garenteed to be consistent. It should only be used to
+    // provded a more readable identifier for the account.
+    fn display_name(&self) -> String;
+    fn sign(&self, payload: &[u8]) -> Ed25519Signature;
+    fn public_key(&self) -> &Ed25519VerifyingKey;
 }


### PR DESCRIPTION
Accounts were introduced in a previous PR however they were local to the core/conversations. This PR moves Accounts to their own crate so they can be re-used in other services.

Changes:
- Adds IdentityProvider trait to `service_traits` so it is available for external implementors. 
- Adds logos-account crate, as it need to be accessible by applications to administer user accounts. This change while perhaps permature, establishes it as an external entity. 
- Updated IdentityProvider::friendly_name -> display_name as suggested by @osmaczko .




Future Work:
- Update core::context to accept an external IdentityProvider impl on construction. 
- Update InboxV2 to use this 