### PR TITLE
feat: receiver recovers both the local identity and the account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,7 +1814,7 @@ dependencies = [
 [[package]]
 name = "de-mls"
 version = "3.0.0"
-source = "git+https://github.com/vacp2p/de-mls?branch=develop#d838e832994fd1d14f624783741bc60b31510fa0"
+source = "git+https://github.com/vacp2p/de-mls?rev=7ae3f03c8dc20711e5ddb712d535dd4b9de74cce#7ae3f03c8dc20711e5ddb712d535dd4b9de74cce"
 dependencies = [
  "hashgraph-like-consensus",
  "indexmap 2.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3250,6 +3250,7 @@ dependencies = [
  "double-ratchets",
  "hashgraph-like-consensus",
  "hex",
+ "logos-account",
  "openmls",
  "openmls_libcrux_crypto 0.3.1",
  "openmls_memory_storage 0.5.0",
@@ -3590,8 +3591,9 @@ name = "logos-account"
 version = "0.1.0"
 dependencies = [
  "crypto",
- "libchat",
+ "hex",
  "shared-traits",
+ "thiserror",
 ]
 
 [[package]]

--- a/core/account/Cargo.toml
+++ b/core/account/Cargo.toml
@@ -9,7 +9,8 @@ dev = []
 [dependencies]
 # Workspace dependencies (sorted)
 crypto = { workspace = true }
-libchat = { workspace = true }
 shared-traits = { workspace = true }
 
 # External dependencies (sorted)
+hex = "0.4.3"
+thiserror = "2.0.17"

--- a/core/account/src/account.rs
+++ b/core/account/src/account.rs
@@ -20,6 +20,12 @@ impl TestLogosAccount {
             verifying_key,
         }
     }
+
+    /// This account's cryptographic id: the hex of its verifying key. This is
+    /// what a credential carries and what `validate_sender` resolves to
+    pub fn iden_id(&self) -> IdentId {
+        IdentId::new(hex::encode(self.verifying_key.as_ref()))
+    }
 }
 
 impl IdentityProvider for TestLogosAccount {

--- a/core/account/src/account.rs
+++ b/core/account/src/account.rs
@@ -1,7 +1,5 @@
 use crypto::{Ed25519SigningKey, Ed25519VerifyingKey};
-use shared_traits::{IdentId, IdentIdRef};
-
-use libchat::IdentityProvider;
+use shared_traits::{IdentId, IdentIdRef, IdentityProvider};
 
 /// A Test Focused LogosAccount using a pre-defined identifier.
 /// The test account is not persisted, and uses a single user provided id.

--- a/core/account/src/credential.rs
+++ b/core/account/src/credential.rs
@@ -1,50 +1,71 @@
-//! Account ↔ LocalIdentity binding carried inside the MLS leaf credential.
+//! The MLS leaf credential as a plain Account claim, plus the service that
+//! validates it.
 //!
-//! A group message in MLS is signed by a per-device key — the **LocalIdentity**
-//! (a device/installation). On its own that key says nothing about which
-//! **Account** the device belongs to, so multiple LocalIdentities of one Account
-//! cannot be collapsed back to that Account on the receiving side.
+//! Two identity scopes meet in a group message:
 //!
-//! This module binds the two together *inside the credential itself*, so a
-//! receiver resolves both without any network round-trip or trusted directory:
+//! - **Signer** — the device key. MLS proves the sender controls it; it *is* the
+//!   LocalIdentity. Surfaced as the leaf's signature key.
+//! - **Credential** — a public *claim* `(AccountId, device public key)`. The
+//!   credential content carries only the claimed Account; the device key is the
+//!   leaf signature key MLS hands us.
 //!
-//! - the MLS leaf's signature key is the LocalIdentity device key (MLS already
-//!   proves the sender holds its private half), and
-//! - the credential content carries the Account key plus the Account's signature
-//!   endorsing that exact device key.
-//!
-//! [`resolve_sender`] verifies the endorsement against the device key the leaf
-//! actually signs with, yielding a [`MessageSender`] the application can trust.
-//! This is the inverse of the account → device directory in `libchat`
-//! (`account_directory`): that resolves an Account *to* its devices for invites;
-//! this resolves a device *back to* its Account on receipt.
+//! A claim is not trusted on its own — anyone can staple any account id next to
+//! their own device key. Trust comes from an account service (the account →
+//! device directory): it answers "is this device key actually registered to
+//! that account?". Decoding ([`decode_credential`]) is therefore separate from
+//! validation: core surfaces the raw [`SenderCredential`], and the client
+//! validates it before reporting an identifier to the application.
 
-use crypto::{Ed25519Signature, Ed25519VerifyingKey};
+use crypto::Ed25519VerifyingKey;
 use shared_traits::IdentId;
 use thiserror::Error;
 
 /// Current credential content version. Bump when [`encode_credential`] changes.
 pub const CREDENTIAL_VERSION: u8 = 1;
 
-/// Domain-separation tag prepended to the credential content and folded into the
-/// endorsement message. The account key may sign other things (e.g. the device
-/// bundle in `account_directory`), so binding to this exact purpose stops a
-/// signature obtained elsewhere from being replayed here. The trailing NUL keeps
-/// it from being a prefix of any other domain.
+/// Domain-separation tag prepended to the credential content, so these bytes
+/// can't be confused with any other signed/encoded payload in the system. The
+/// trailing NUL keeps it from being a prefix of any other domain.
 pub const CREDENTIAL_DOMAIN: &[u8] = b"libchat:account-local-identity\0";
 
-/// The verified sender of a group message: which Account, and which device
-/// (LocalIdentity) of that Account it was sent from. Both are hex-encoded
-/// Ed25519 verifying keys.
+/// The raw, *unvalidated* sender of a group message, decoded from the MLS
+/// credential: the claimed Account and the device (LocalIdentity) it was sent
+/// from. Both are hex-encoded Ed25519 verifying keys.
+///
+/// The `local_identity` is trustworthy on its own — MLS verified the message
+/// against that device key. The `account` is only a *claim* until an
+/// [`AccountService`] confirms the device belongs to it.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct MessageSender {
-    /// The Account the sending device belongs to.
+pub struct SenderCredential {
+    /// The Account the sender *claims* to belong to (hex of the account key).
     pub account: IdentId,
-    /// The specific LocalIdentity (device/installation) that sent the message.
+    /// The device/LocalIdentity that sent the message (hex of the leaf key).
     pub local_identity: IdentId,
 }
 
-/// Failures decoding or verifying an account-bound credential.
+/// The validated identifier handed to the application: a [`SenderCredential`]
+/// whose account claim an [`AccountService`] has confirmed. Same shape as the
+/// credential, but the distinct type marks that validation has happened.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MessageSender {
+    /// The confirmed Account the sending device belongs to.
+    pub account: IdentId,
+    /// The specific LocalIdentity (device) that sent the message.
+    pub local_identity: IdentId,
+}
+
+impl MessageSender {
+    /// Promote a validated credential to an identifier. Call only *after* an
+    /// [`AccountService`] has confirmed the claim.
+    pub fn validated(cred: SenderCredential) -> Self {
+        Self {
+            account: cred.account,
+            local_identity: cred.local_identity,
+        }
+    }
+}
+
+/// Failures decoding a credential.
 #[derive(Debug, Error)]
 pub enum CredentialError {
     #[error("credential is missing the account-local-identity domain prefix")]
@@ -55,62 +76,35 @@ pub enum CredentialError {
     Version(u8),
     #[error("credential carries a malformed account key")]
     AccountKey,
-    #[error("account endorsement of the local identity failed verification")]
-    SignatureInvalid,
 }
 
-/// The bytes the Account signs to endorse `device` as one of its LocalIdentities.
+/// Encode the MLS credential content: the Account claim.
 ///
-/// `account` is folded in alongside the device key so the signature is bound to
-/// the specific (account, device) pair, not just the device key in isolation.
-fn endorsement_message(account: &Ed25519VerifyingKey, device: &Ed25519VerifyingKey) -> Vec<u8> {
-    let mut msg = Vec::with_capacity(CREDENTIAL_DOMAIN.len() + 32 + 32);
-    msg.extend_from_slice(CREDENTIAL_DOMAIN);
-    msg.extend_from_slice(account.as_ref());
-    msg.extend_from_slice(device.as_ref());
-    msg
-}
-
-/// Produce the Account's endorsement of `device`, using the Account's signing
-/// capability. `sign` is the account authority's signer (a local key on testnet,
-/// or an external wallet/enclave), so the closure is fallible.
-pub fn endorse_local_identity<E>(
-    account: &Ed25519VerifyingKey,
-    device: &Ed25519VerifyingKey,
-    sign: impl FnOnce(&[u8]) -> Result<Ed25519Signature, E>,
-) -> Result<Ed25519Signature, E> {
-    sign(&endorsement_message(account, device))
-}
-
-/// Encode the MLS credential content that binds a LocalIdentity to its Account.
-///
-/// The device key is *not* embedded: it is the leaf's signature key, supplied
-/// out-of-band by MLS on the receiving side and passed to [`resolve_sender`].
+/// The device key is *not* embedded — it is the leaf's signature key, supplied
+/// out-of-band by MLS on the receiving side and paired in [`decode_credential`].
 ///
 /// ```text
 /// domain      : CREDENTIAL_DOMAIN    (constant prefix, NUL-terminated)
 /// version     : u8        (1 byte)
 /// account_pub : [u8; 32]  (32 bytes)
-/// endorsement : [u8; 64]  (64 bytes) — account signature over endorsement_message
 /// ```
-pub fn encode_credential(account: &Ed25519VerifyingKey, endorsement: &Ed25519Signature) -> Vec<u8> {
-    let mut out = Vec::with_capacity(CREDENTIAL_DOMAIN.len() + 1 + 32 + 64);
+pub fn encode_credential(account: &Ed25519VerifyingKey) -> Vec<u8> {
+    let mut out = Vec::with_capacity(CREDENTIAL_DOMAIN.len() + 1 + 32);
     out.extend_from_slice(CREDENTIAL_DOMAIN);
     out.push(CREDENTIAL_VERSION);
     out.extend_from_slice(account.as_ref());
-    out.extend_from_slice(endorsement.as_ref());
     out
 }
 
-/// Decode `credential_content` and verify the Account's endorsement against
-/// `device_key` — the key the MLS leaf actually signs with. On success the
-/// caller learns both the LocalIdentity (`device_key`) and the Account that
-/// vouches for it.
-pub fn resolve_sender(
+/// Decode `credential_content` into the raw claim, pairing the embedded Account
+/// with `device_key` (the key the MLS leaf actually signs with). This does *not*
+/// validate the claim — the account is only asserted until checked against an
+/// [`AccountService`].
+pub fn decode_credential(
     credential_content: &[u8],
     device_key: &Ed25519VerifyingKey,
-) -> Result<MessageSender, CredentialError> {
-    const HEADER: usize = 1 + 32 + 64;
+) -> Result<SenderCredential, CredentialError> {
+    const HEADER: usize = 1 + 32;
     let rest = credential_content
         .strip_prefix(CREDENTIAL_DOMAIN)
         .ok_or(CredentialError::Domain)?;
@@ -121,21 +115,11 @@ pub fn resolve_sender(
     if version != CREDENTIAL_VERSION {
         return Err(CredentialError::Version(version));
     }
-
     let account_bytes: [u8; 32] = rest[1..33].try_into().expect("33 - 1 == 32");
     let account =
         Ed25519VerifyingKey::from_bytes(&account_bytes).map_err(|_| CredentialError::AccountKey)?;
-    let sig_bytes: [u8; 64] = rest[33..97].try_into().expect("97 - 33 == 64");
-    let endorsement = Ed25519Signature::from(sig_bytes);
 
-    // Verifying under the account key, over a message that includes the *leaf's*
-    // device key, is what binds this device to this account. A credential lifted
-    // from another sender won't verify against the device key MLS hands us here.
-    account
-        .verify(&endorsement_message(&account, device_key), &endorsement)
-        .map_err(|_| CredentialError::SignatureInvalid)?;
-
-    Ok(MessageSender {
+    Ok(SenderCredential {
         account: IdentId::new(hex::encode(account.as_ref())),
         local_identity: IdentId::new(hex::encode(device_key.as_ref())),
     })
@@ -145,97 +129,38 @@ pub fn resolve_sender(
 mod tests {
     use super::*;
     use crypto::Ed25519SigningKey;
-    use std::convert::Infallible;
 
-    /// Sign with the account key, resolve under the device key: both identities
-    /// come back, hex-encoded.
+    /// encode → decode pairs the embedded account with the supplied device key.
     #[test]
-    fn resolves_well_formed_credential() {
-        let account_key = Ed25519SigningKey::generate();
-        let account_pub = account_key.verifying_key();
-        let device_key = Ed25519SigningKey::generate();
-        let device_pub = device_key.verifying_key();
+    fn decodes_well_formed_credential() {
+        let account = Ed25519SigningKey::generate().verifying_key();
+        let device = Ed25519SigningKey::generate().verifying_key();
 
-        let endorsement = endorse_local_identity::<Infallible>(&account_pub, &device_pub, |m| {
-            Ok(account_key.sign(m))
-        })
-        .unwrap();
-        let content = encode_credential(&account_pub, &endorsement);
+        let content = encode_credential(&account);
+        let cred = decode_credential(&content, &device).unwrap();
 
-        let sender = resolve_sender(&content, &device_pub).unwrap();
-        assert_eq!(sender.account.as_str(), hex::encode(account_pub.as_ref()));
-        assert_eq!(
-            sender.local_identity.as_str(),
-            hex::encode(device_pub.as_ref())
-        );
-    }
-
-    /// On testnet the account key *is* the device key (one device == one
-    /// account); resolution then reports the same id for both.
-    #[test]
-    fn single_key_account_resolves_to_itself() {
-        let key = Ed25519SigningKey::generate();
-        let pubkey = key.verifying_key();
-
-        let endorsement =
-            endorse_local_identity::<Infallible>(&pubkey, &pubkey, |m| Ok(key.sign(m))).unwrap();
-        let content = encode_credential(&pubkey, &endorsement);
-
-        let sender = resolve_sender(&content, &pubkey).unwrap();
-        assert_eq!(sender.account, sender.local_identity);
-    }
-
-    /// An endorsement for device A, presented with device B's key (as MLS would
-    /// hand it over if B forged a leaf), fails: the signature covers A's key.
-    #[test]
-    fn rejects_endorsement_for_a_different_device() {
-        let account_key = Ed25519SigningKey::generate();
-        let account_pub = account_key.verifying_key();
-        let device_a = Ed25519SigningKey::generate().verifying_key();
-        let device_b = Ed25519SigningKey::generate().verifying_key();
-
-        let endorsement = endorse_local_identity::<Infallible>(&account_pub, &device_a, |m| {
-            Ok(account_key.sign(m))
-        })
-        .unwrap();
-        let content = encode_credential(&account_pub, &endorsement);
-
-        assert!(matches!(
-            resolve_sender(&content, &device_b),
-            Err(CredentialError::SignatureInvalid)
-        ));
+        assert_eq!(cred.account.as_str(), hex::encode(account.as_ref()));
+        assert_eq!(cred.local_identity.as_str(), hex::encode(device.as_ref()));
     }
 
     #[test]
     fn rejects_missing_domain_short_and_bad_version() {
-        let account_key = Ed25519SigningKey::generate();
-        let account_pub = account_key.verifying_key();
+        let account = Ed25519SigningKey::generate().verifying_key();
         let device = Ed25519SigningKey::generate().verifying_key();
-        let endorsement =
-            endorse_local_identity::<Infallible>(
-                &account_pub,
-                &device,
-                |m| Ok(account_key.sign(m)),
-            )
-            .unwrap();
-        let content = encode_credential(&account_pub, &endorsement);
+        let content = encode_credential(&account);
 
-        // Strip the domain prefix.
         assert!(matches!(
-            resolve_sender(&content[CREDENTIAL_DOMAIN.len()..], &device),
+            decode_credential(&content[CREDENTIAL_DOMAIN.len()..], &device),
             Err(CredentialError::Domain)
         ));
-        // Domain present but body truncated.
-        let short = &content[..CREDENTIAL_DOMAIN.len() + 4];
         assert!(matches!(
-            resolve_sender(short, &device),
+            decode_credential(&content[..CREDENTIAL_DOMAIN.len() + 1], &device),
             Err(CredentialError::Short)
         ));
-        // Wrong version byte (first byte after the domain prefix).
         let mut bad_version = content.clone();
         bad_version[CREDENTIAL_DOMAIN.len()] = 99;
         assert!(matches!(
-            resolve_sender(&bad_version, &device),
+            decode_credential(&bad_version, &device),
             Err(CredentialError::Version(99))
         ));
     }

--- a/core/account/src/credential.rs
+++ b/core/account/src/credential.rs
@@ -1,0 +1,242 @@
+//! Account ↔ LocalIdentity binding carried inside the MLS leaf credential.
+//!
+//! A group message in MLS is signed by a per-device key — the **LocalIdentity**
+//! (a device/installation). On its own that key says nothing about which
+//! **Account** the device belongs to, so multiple LocalIdentities of one Account
+//! cannot be collapsed back to that Account on the receiving side.
+//!
+//! This module binds the two together *inside the credential itself*, so a
+//! receiver resolves both without any network round-trip or trusted directory:
+//!
+//! - the MLS leaf's signature key is the LocalIdentity device key (MLS already
+//!   proves the sender holds its private half), and
+//! - the credential content carries the Account key plus the Account's signature
+//!   endorsing that exact device key.
+//!
+//! [`resolve_sender`] verifies the endorsement against the device key the leaf
+//! actually signs with, yielding a [`MessageSender`] the application can trust.
+//! This is the inverse of the account → device directory in `libchat`
+//! (`account_directory`): that resolves an Account *to* its devices for invites;
+//! this resolves a device *back to* its Account on receipt.
+
+use crypto::{Ed25519Signature, Ed25519VerifyingKey};
+use shared_traits::IdentId;
+use thiserror::Error;
+
+/// Current credential content version. Bump when [`encode_credential`] changes.
+pub const CREDENTIAL_VERSION: u8 = 1;
+
+/// Domain-separation tag prepended to the credential content and folded into the
+/// endorsement message. The account key may sign other things (e.g. the device
+/// bundle in `account_directory`), so binding to this exact purpose stops a
+/// signature obtained elsewhere from being replayed here. The trailing NUL keeps
+/// it from being a prefix of any other domain.
+pub const CREDENTIAL_DOMAIN: &[u8] = b"libchat:account-local-identity\0";
+
+/// The verified sender of a group message: which Account, and which device
+/// (LocalIdentity) of that Account it was sent from. Both are hex-encoded
+/// Ed25519 verifying keys.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MessageSender {
+    /// The Account the sending device belongs to.
+    pub account: IdentId,
+    /// The specific LocalIdentity (device/installation) that sent the message.
+    pub local_identity: IdentId,
+}
+
+/// Failures decoding or verifying an account-bound credential.
+#[derive(Debug, Error)]
+pub enum CredentialError {
+    #[error("credential is missing the account-local-identity domain prefix")]
+    Domain,
+    #[error("credential shorter than its declared layout")]
+    Short,
+    #[error("unsupported credential version {0}")]
+    Version(u8),
+    #[error("credential carries a malformed account key")]
+    AccountKey,
+    #[error("account endorsement of the local identity failed verification")]
+    SignatureInvalid,
+}
+
+/// The bytes the Account signs to endorse `device` as one of its LocalIdentities.
+///
+/// `account` is folded in alongside the device key so the signature is bound to
+/// the specific (account, device) pair, not just the device key in isolation.
+fn endorsement_message(account: &Ed25519VerifyingKey, device: &Ed25519VerifyingKey) -> Vec<u8> {
+    let mut msg = Vec::with_capacity(CREDENTIAL_DOMAIN.len() + 32 + 32);
+    msg.extend_from_slice(CREDENTIAL_DOMAIN);
+    msg.extend_from_slice(account.as_ref());
+    msg.extend_from_slice(device.as_ref());
+    msg
+}
+
+/// Produce the Account's endorsement of `device`, using the Account's signing
+/// capability. `sign` is the account authority's signer (a local key on testnet,
+/// or an external wallet/enclave), so the closure is fallible.
+pub fn endorse_local_identity<E>(
+    account: &Ed25519VerifyingKey,
+    device: &Ed25519VerifyingKey,
+    sign: impl FnOnce(&[u8]) -> Result<Ed25519Signature, E>,
+) -> Result<Ed25519Signature, E> {
+    sign(&endorsement_message(account, device))
+}
+
+/// Encode the MLS credential content that binds a LocalIdentity to its Account.
+///
+/// The device key is *not* embedded: it is the leaf's signature key, supplied
+/// out-of-band by MLS on the receiving side and passed to [`resolve_sender`].
+///
+/// ```text
+/// domain      : CREDENTIAL_DOMAIN    (constant prefix, NUL-terminated)
+/// version     : u8        (1 byte)
+/// account_pub : [u8; 32]  (32 bytes)
+/// endorsement : [u8; 64]  (64 bytes) — account signature over endorsement_message
+/// ```
+pub fn encode_credential(account: &Ed25519VerifyingKey, endorsement: &Ed25519Signature) -> Vec<u8> {
+    let mut out = Vec::with_capacity(CREDENTIAL_DOMAIN.len() + 1 + 32 + 64);
+    out.extend_from_slice(CREDENTIAL_DOMAIN);
+    out.push(CREDENTIAL_VERSION);
+    out.extend_from_slice(account.as_ref());
+    out.extend_from_slice(endorsement.as_ref());
+    out
+}
+
+/// Decode `credential_content` and verify the Account's endorsement against
+/// `device_key` — the key the MLS leaf actually signs with. On success the
+/// caller learns both the LocalIdentity (`device_key`) and the Account that
+/// vouches for it.
+pub fn resolve_sender(
+    credential_content: &[u8],
+    device_key: &Ed25519VerifyingKey,
+) -> Result<MessageSender, CredentialError> {
+    const HEADER: usize = 1 + 32 + 64;
+    let rest = credential_content
+        .strip_prefix(CREDENTIAL_DOMAIN)
+        .ok_or(CredentialError::Domain)?;
+    if rest.len() < HEADER {
+        return Err(CredentialError::Short);
+    }
+    let version = rest[0];
+    if version != CREDENTIAL_VERSION {
+        return Err(CredentialError::Version(version));
+    }
+
+    let account_bytes: [u8; 32] = rest[1..33].try_into().expect("33 - 1 == 32");
+    let account =
+        Ed25519VerifyingKey::from_bytes(&account_bytes).map_err(|_| CredentialError::AccountKey)?;
+    let sig_bytes: [u8; 64] = rest[33..97].try_into().expect("97 - 33 == 64");
+    let endorsement = Ed25519Signature::from(sig_bytes);
+
+    // Verifying under the account key, over a message that includes the *leaf's*
+    // device key, is what binds this device to this account. A credential lifted
+    // from another sender won't verify against the device key MLS hands us here.
+    account
+        .verify(&endorsement_message(&account, device_key), &endorsement)
+        .map_err(|_| CredentialError::SignatureInvalid)?;
+
+    Ok(MessageSender {
+        account: IdentId::new(hex::encode(account.as_ref())),
+        local_identity: IdentId::new(hex::encode(device_key.as_ref())),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crypto::Ed25519SigningKey;
+    use std::convert::Infallible;
+
+    /// Sign with the account key, resolve under the device key: both identities
+    /// come back, hex-encoded.
+    #[test]
+    fn resolves_well_formed_credential() {
+        let account_key = Ed25519SigningKey::generate();
+        let account_pub = account_key.verifying_key();
+        let device_key = Ed25519SigningKey::generate();
+        let device_pub = device_key.verifying_key();
+
+        let endorsement = endorse_local_identity::<Infallible>(&account_pub, &device_pub, |m| {
+            Ok(account_key.sign(m))
+        })
+        .unwrap();
+        let content = encode_credential(&account_pub, &endorsement);
+
+        let sender = resolve_sender(&content, &device_pub).unwrap();
+        assert_eq!(sender.account.as_str(), hex::encode(account_pub.as_ref()));
+        assert_eq!(
+            sender.local_identity.as_str(),
+            hex::encode(device_pub.as_ref())
+        );
+    }
+
+    /// On testnet the account key *is* the device key (one device == one
+    /// account); resolution then reports the same id for both.
+    #[test]
+    fn single_key_account_resolves_to_itself() {
+        let key = Ed25519SigningKey::generate();
+        let pubkey = key.verifying_key();
+
+        let endorsement =
+            endorse_local_identity::<Infallible>(&pubkey, &pubkey, |m| Ok(key.sign(m))).unwrap();
+        let content = encode_credential(&pubkey, &endorsement);
+
+        let sender = resolve_sender(&content, &pubkey).unwrap();
+        assert_eq!(sender.account, sender.local_identity);
+    }
+
+    /// An endorsement for device A, presented with device B's key (as MLS would
+    /// hand it over if B forged a leaf), fails: the signature covers A's key.
+    #[test]
+    fn rejects_endorsement_for_a_different_device() {
+        let account_key = Ed25519SigningKey::generate();
+        let account_pub = account_key.verifying_key();
+        let device_a = Ed25519SigningKey::generate().verifying_key();
+        let device_b = Ed25519SigningKey::generate().verifying_key();
+
+        let endorsement = endorse_local_identity::<Infallible>(&account_pub, &device_a, |m| {
+            Ok(account_key.sign(m))
+        })
+        .unwrap();
+        let content = encode_credential(&account_pub, &endorsement);
+
+        assert!(matches!(
+            resolve_sender(&content, &device_b),
+            Err(CredentialError::SignatureInvalid)
+        ));
+    }
+
+    #[test]
+    fn rejects_missing_domain_short_and_bad_version() {
+        let account_key = Ed25519SigningKey::generate();
+        let account_pub = account_key.verifying_key();
+        let device = Ed25519SigningKey::generate().verifying_key();
+        let endorsement =
+            endorse_local_identity::<Infallible>(
+                &account_pub,
+                &device,
+                |m| Ok(account_key.sign(m)),
+            )
+            .unwrap();
+        let content = encode_credential(&account_pub, &endorsement);
+
+        // Strip the domain prefix.
+        assert!(matches!(
+            resolve_sender(&content[CREDENTIAL_DOMAIN.len()..], &device),
+            Err(CredentialError::Domain)
+        ));
+        // Domain present but body truncated.
+        let short = &content[..CREDENTIAL_DOMAIN.len() + 4];
+        assert!(matches!(
+            resolve_sender(short, &device),
+            Err(CredentialError::Short)
+        ));
+        // Wrong version byte (first byte after the domain prefix).
+        let mut bad_version = content.clone();
+        bad_version[CREDENTIAL_DOMAIN.len()] = 99;
+        assert!(matches!(
+            resolve_sender(&bad_version, &device),
+            Err(CredentialError::Version(99))
+        ));
+    }
+}

--- a/core/account/src/lib.rs
+++ b/core/account/src/lib.rs
@@ -1,3 +1,10 @@
+mod credential;
+
+pub use credential::{
+    CREDENTIAL_DOMAIN, CREDENTIAL_VERSION, CredentialError, MessageSender, encode_credential,
+    endorse_local_identity, resolve_sender,
+};
+
 #[cfg(feature = "dev")]
 mod account;
 

--- a/core/account/src/lib.rs
+++ b/core/account/src/lib.rs
@@ -1,8 +1,8 @@
 mod credential;
 
 pub use credential::{
-    CREDENTIAL_DOMAIN, CREDENTIAL_VERSION, CredentialError, MessageSender, encode_credential,
-    endorse_local_identity, resolve_sender,
+    CREDENTIAL_DOMAIN, CREDENTIAL_VERSION, CredentialError, MessageSender, SenderCredential,
+    decode_credential, encode_credential,
 };
 
 #[cfg(feature = "dev")]

--- a/core/conversations/Cargo.toml
+++ b/core/conversations/Cargo.toml
@@ -19,7 +19,7 @@ storage = { workspace = true }
 alloy = "2.0"
 base64 = "0.22"
 chat-proto = { git = "https://github.com/logos-messaging/chat_proto", rev = "37ec98a151f6d50aab2905802ac0a896477e62ea" }
-de-mls = { git = "https://github.com/vacp2p/de-mls", branch = "develop" }
+de-mls = { git = "https://github.com/vacp2p/de-mls", rev = "7ae3f03c8dc20711e5ddb712d535dd4b9de74cce" }
 double-ratchets = { path = "../double-ratchets" }
 hashgraph-like-consensus = "0.5.1"
 hex = "0.4.3"

--- a/core/conversations/Cargo.toml
+++ b/core/conversations/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["rlib"]
 blake2 = { workspace = true }
 chat-sqlite = { workspace = true }
 crypto = { workspace = true }
+logos-account = { workspace = true }
 shared-traits = { workspace = true }
 storage = { workspace = true }
 

--- a/core/conversations/src/account_directory.rs
+++ b/core/conversations/src/account_directory.rs
@@ -108,6 +108,40 @@ pub trait AccountDirectory: Debug {
     fn fetch(&self, account: &Ed25519VerifyingKey) -> Result<Option<DeviceSet>, Self::Error>;
 }
 
+/// Confirms whether a device key really belongs to an account — the trust step
+/// a [`SenderCredential`](logos_account::SenderCredential)'s account claim is
+/// checked against before it is reported to the application.
+///
+/// Backed by the [`AccountDirectory`]: any directory client is an
+/// `AccountService` via the blanket impl below, which fetches the account's
+/// verified device set and checks membership.
+pub trait AccountService {
+    type Error: Display + Debug;
+
+    /// True if `device` is a registered LocalIdentity of `account`.
+    fn is_local_identity_of(
+        &self,
+        account: &Ed25519VerifyingKey,
+        device: &Ed25519VerifyingKey,
+    ) -> Result<bool, Self::Error>;
+}
+
+impl<D: AccountDirectory> AccountService for D {
+    type Error = <D as AccountDirectory>::Error;
+
+    fn is_local_identity_of(
+        &self,
+        account: &Ed25519VerifyingKey,
+        device: &Ed25519VerifyingKey,
+    ) -> Result<bool, Self::Error> {
+        // No published bundle → can't confirm the device belongs to the account.
+        let Some(set) = self.fetch(account)? else {
+            return Ok(false);
+        };
+        Ok(set.devices.contains(&hex::encode(device.as_ref())))
+    }
+}
+
 /// Failures decoding or verifying a [`SignedDeviceBundle`].
 #[derive(Debug, Error)]
 pub enum BundleError {
@@ -393,6 +427,36 @@ mod tests {
         let resolved = resolve_device_ids(&FakeDir(Some(bundle)), &account_id).unwrap();
         let want: Vec<String> = devices.iter().map(|d| hex::encode(d.as_ref())).collect();
         assert_eq!(resolved, want);
+    }
+
+    /// `AccountService` (blanket impl over the directory): a published device
+    /// validates for its account; a stranger device and an unknown account do
+    /// not.
+    #[test]
+    fn account_service_checks_device_membership() {
+        let account_key = Ed25519SigningKey::generate();
+        let account_pub = account_key.verifying_key();
+        let device = Ed25519SigningKey::generate().verifying_key();
+        let stranger = Ed25519SigningKey::generate().verifying_key();
+
+        let payload = encode_bundle_payload(1, std::slice::from_ref(&device));
+        let bundle = SignedDeviceBundle {
+            account_pub: account_pub.clone(),
+            signature: account_key.sign(&payload),
+            payload,
+        };
+        let dir = FakeDir(Some(bundle));
+
+        assert!(dir.is_local_identity_of(&account_pub, &device).unwrap());
+        assert!(!dir.is_local_identity_of(&account_pub, &stranger).unwrap());
+
+        // An account with no published bundle can't confirm anything.
+        let unknown = Ed25519SigningKey::generate().verifying_key();
+        assert!(
+            !FakeDir(None)
+                .is_local_identity_of(&unknown, &device)
+                .unwrap()
+        );
     }
 
     /// Tampering with any payload byte breaks verification.

--- a/core/conversations/src/account_service.rs
+++ b/core/conversations/src/account_service.rs
@@ -1,17 +1,19 @@
-//! Account → device directory: traits and the signed device-list bundle codec.
+//! The account service: the injected client to chat-store's account endpoints,
+//! plus the signed device-list bundle codec it deals in.
 //!
 //! An Account (AccountAddress, an Ed25519 key) endorses a set of device
-//! (LocalIdentity) public keys by signing a bundle. The directory service stores
+//! (LocalIdentity) public keys by signing a bundle. The account service stores
 //! one such bundle per account so that an inviter can resolve an account public
-//! key to every device it must invite.
+//! key to every device it must invite, and a receiver can confirm a device
+//! belongs to a claimed account.
 //!
 //! Two roles are kept distinct from the per-device [`IdentityProvider`]:
 //!
 //! - [`AccountAuthority`] — the injected account key. Custody (wallet, enclave,
 //!   another device) stays outside libchat; we only ever ask it to sign. Present
 //!   only where the user authorizes a device change.
-//! - [`AccountDirectory`] — the client that publishes and fetches+verifies the
-//!   bundle against the directory service.
+//! - [`AccountService`] — the client that publishes, fetches+verifies, and
+//!   answers membership questions against the account service (chat-store).
 //!
 //! The bundle `payload` is opaque to the server. Both the signing side
 //! ([`encode_bundle_payload`]) and the verifying side ([`verify_bundle`]) live
@@ -91,13 +93,17 @@ pub trait AccountAuthority {
     fn sign(&self, payload: &[u8]) -> Result<Ed25519Signature, Self::Error>;
 }
 
-/// Client for the account → device directory service.
+/// The injected client to chat-store's account endpoints.
 ///
 /// Mirrors [`RegistrationService`](crate::service_traits::RegistrationService):
 /// an injected trait in core with an HTTP implementation in the extension layer.
-/// The service is untrusted, so [`fetch`](AccountDirectory::fetch) verifies the
+/// The service is untrusted, so [`fetch`](AccountService::fetch) verifies the
 /// account signature before returning a [`DeviceSet`].
-pub trait AccountDirectory: Debug {
+///
+/// Covers the full account surface: publishing this account's device list,
+/// fetching another account's, and the derived membership check used to validate
+/// a [`SenderCredential`](logos_account::SenderCredential)'s account claim.
+pub trait AccountService: Debug {
     type Error: Display + Debug;
 
     /// Upsert the signed device list for an account, replacing any previous one.
@@ -106,35 +112,16 @@ pub trait AccountDirectory: Debug {
     /// Fetch and verify the device set for `account`. `Ok(None)` means the
     /// account has never published — callers fall back to legacy 1:1 resolution.
     fn fetch(&self, account: &Ed25519VerifyingKey) -> Result<Option<DeviceSet>, Self::Error>;
-}
 
-/// Confirms whether a device key really belongs to an account — the trust step
-/// a [`SenderCredential`](logos_account::SenderCredential)'s account claim is
-/// checked against before it is reported to the application.
-///
-/// Backed by the [`AccountDirectory`]: any directory client is an
-/// `AccountService` via the blanket impl below, which fetches the account's
-/// verified device set and checks membership.
-pub trait AccountService {
-    type Error: Display + Debug;
-
-    /// True if `device` is a registered LocalIdentity of `account`.
-    fn is_local_identity_of(
-        &self,
-        account: &Ed25519VerifyingKey,
-        device: &Ed25519VerifyingKey,
-    ) -> Result<bool, Self::Error>;
-}
-
-impl<D: AccountDirectory> AccountService for D {
-    type Error = <D as AccountDirectory>::Error;
-
+    /// True if `device` is a registered LocalIdentity of `account` — the trust
+    /// step a sender's account *claim* is checked against. Derived from
+    /// [`fetch`](AccountService::fetch): no published bundle means the binding
+    /// can't be confirmed, so the answer is `false`.
     fn is_local_identity_of(
         &self,
         account: &Ed25519VerifyingKey,
         device: &Ed25519VerifyingKey,
     ) -> Result<bool, Self::Error> {
-        // No published bundle → can't confirm the device belongs to the account.
         let Some(set) = self.fetch(account)? else {
             return Ok(false);
         };
@@ -249,7 +236,7 @@ pub fn verify_bundle(
 /// of such a key and a bundle exists, returns its verified device set. Otherwise
 /// falls back to treating the identifier itself as a single device id — the
 /// pre-directory behaviour — so opaque or never-published ids keep working.
-pub fn resolve_device_ids<D: AccountDirectory + ?Sized>(
+pub fn resolve_device_ids<D: AccountService + ?Sized>(
     directory: &D,
     account: IdentIdRef,
 ) -> Result<Vec<DeviceId>, D::Error> {
@@ -383,7 +370,7 @@ mod tests {
     #[derive(Debug, Default)]
     struct FakeDir(Option<SignedDeviceBundle>);
 
-    impl AccountDirectory for FakeDir {
+    impl AccountService for FakeDir {
         type Error = BundleError;
         fn publish(&mut self, bundle: &SignedDeviceBundle) -> Result<(), Self::Error> {
             self.0 = Some(bundle.clone());

--- a/core/conversations/src/conversation/group_v1.rs
+++ b/core/conversations/src/conversation/group_v1.rs
@@ -5,6 +5,8 @@
 use blake2::{Blake2b, Digest, digest::consts::U6};
 use chat_proto::logoschat::encryption::{EncryptedPayload, Plaintext, encrypted_payload};
 use chat_proto::logoschat::reliability::ReliablePayload;
+use crypto::Ed25519VerifyingKey;
+use logos_account::MessageSender;
 use openmls::prelude::tls_codec::Deserialize;
 use openmls::prelude::*;
 use prost::Message as _;
@@ -40,13 +42,9 @@ impl GroupV1Convo {
     // Create a new conversation with the creator as the only participant.
     pub fn new<S: ExternalServices>(cx: &mut ServiceContext<S>) -> Result<Self, ChatError> {
         let config = Self::mls_create_config(cx);
-        let mls_group = MlsGroup::new(
-            &cx.mls_provider,
-            &cx.mls_identity,
-            &config,
-            cx.mls_identity.get_credential(),
-        )
-        .unwrap();
+        let credential = cx.mls_identity.get_credential()?;
+        let mls_group =
+            MlsGroup::new(&cx.mls_provider, &cx.mls_identity, &config, credential).unwrap();
         let convo_id = hex::encode(mls_group.group_id().as_slice());
         Self::subscribe(&mut cx.ds, &convo_id)?;
 
@@ -178,6 +176,26 @@ impl GroupV1Convo {
         &self.convo_id
     }
 
+    /// Resolve the verified [`MessageSender`] for a processed message.
+    ///
+    /// MLS guarantees the message was signed by the sender leaf's key, which is
+    /// the device (LocalIdentity) key. We pair that authoritative key with the
+    /// account binding carried in the credential to recover both the Account and
+    /// the LocalIdentity. Returns `None` for non-member senders or if the
+    /// credential isn't a well-formed, validly-endorsed account binding.
+    fn resolve_sender(&self, processed: &ProcessedMessage) -> Option<MessageSender> {
+        let Sender::Member(leaf_index) = processed.sender() else {
+            return None;
+        };
+        // The leaf's signature key is the device key MLS verified the message
+        // against — the trustworthy LocalIdentity, not anything self-asserted in
+        // the credential content.
+        let member = self.mls_group.member_at(*leaf_index)?;
+        let key_bytes: [u8; 32] = member.signature_key.as_slice().try_into().ok()?;
+        let device_key = Ed25519VerifyingKey::from_bytes(&key_bytes).ok()?;
+        logos_account::resolve_sender(processed.credential().serialized_content(), &device_key).ok()
+    }
+
     fn send_message<S: ExternalServices>(
         &mut self,
         content: &[u8],
@@ -252,6 +270,10 @@ impl<S: ExternalServices> Convo<S> for GroupV1Convo {
             .process_message(&cx.mls_provider, protocol_message)
             .map_err(ChatError::generic)?;
 
+        // Resolve the sender before consuming `processed`; only surfaced
+        // alongside application content below.
+        let sender = self.resolve_sender(&processed);
+
         let content = match processed.into_content() {
             ProcessedMessageContent::ApplicationMessage(msg) => {
                 let reliable = ReliablePayload::decode(msg.into_bytes().as_slice())?;
@@ -271,9 +293,14 @@ impl<S: ExternalServices> Convo<S> for GroupV1Convo {
                 None
             }
         };
+        // A commit (content == None) has a sender but no application payload;
+        // keep the sender paired with content so consumers see it only on
+        // actual messages.
+        let sender = content.as_ref().and(sender);
         Ok(ConvoOutcome {
             convo_id: self.id().to_string(),
             content,
+            sender,
         })
     }
 

--- a/core/conversations/src/conversation/group_v1.rs
+++ b/core/conversations/src/conversation/group_v1.rs
@@ -6,7 +6,7 @@ use blake2::{Blake2b, Digest, digest::consts::U6};
 use chat_proto::logoschat::encryption::{EncryptedPayload, Plaintext, encrypted_payload};
 use chat_proto::logoschat::reliability::ReliablePayload;
 use crypto::Ed25519VerifyingKey;
-use logos_account::MessageSender;
+use logos_account::SenderCredential;
 use openmls::prelude::tls_codec::Deserialize;
 use openmls::prelude::*;
 use prost::Message as _;
@@ -176,24 +176,25 @@ impl GroupV1Convo {
         &self.convo_id
     }
 
-    /// Resolve the verified [`MessageSender`] for a processed message.
+    /// Decode the (unvalidated) [`SenderCredential`] for a processed message.
     ///
     /// MLS guarantees the message was signed by the sender leaf's key, which is
     /// the device (LocalIdentity) key. We pair that authoritative key with the
-    /// account binding carried in the credential to recover both the Account and
-    /// the LocalIdentity. Returns `None` for non-member senders or if the
-    /// credential isn't a well-formed, validly-endorsed account binding.
-    fn resolve_sender(&self, processed: &ProcessedMessage) -> Option<MessageSender> {
+    /// Account *claim* carried in the credential content. The account claim is
+    /// not trusted here — the client validates it against an
+    /// [`AccountService`](logos_account::AccountService). Returns `None` for
+    /// non-member senders or a malformed credential.
+    fn sender_credential(&self, processed: &ProcessedMessage) -> Option<SenderCredential> {
         let Sender::Member(leaf_index) = processed.sender() else {
             return None;
         };
         // The leaf's signature key is the device key MLS verified the message
-        // against — the trustworthy LocalIdentity, not anything self-asserted in
-        // the credential content.
+        // against — the trustworthy LocalIdentity.
         let member = self.mls_group.member_at(*leaf_index)?;
         let key_bytes: [u8; 32] = member.signature_key.as_slice().try_into().ok()?;
         let device_key = Ed25519VerifyingKey::from_bytes(&key_bytes).ok()?;
-        logos_account::resolve_sender(processed.credential().serialized_content(), &device_key).ok()
+        logos_account::decode_credential(processed.credential().serialized_content(), &device_key)
+            .ok()
     }
 
     fn send_message<S: ExternalServices>(
@@ -270,9 +271,9 @@ impl<S: ExternalServices> Convo<S> for GroupV1Convo {
             .process_message(&cx.mls_provider, protocol_message)
             .map_err(ChatError::generic)?;
 
-        // Resolve the sender before consuming `processed`; only surfaced
-        // alongside application content below.
-        let sender = self.resolve_sender(&processed);
+        // Decode the sender credential before consuming `processed`; only
+        // surfaced alongside application content below.
+        let credential = self.sender_credential(&processed);
 
         let content = match processed.into_content() {
             ProcessedMessageContent::ApplicationMessage(msg) => {
@@ -293,14 +294,14 @@ impl<S: ExternalServices> Convo<S> for GroupV1Convo {
                 None
             }
         };
-        // A commit (content == None) has a sender but no application payload;
-        // keep the sender paired with content so consumers see it only on
-        // actual messages.
-        let sender = content.as_ref().and(sender);
+        // A commit (content == None) has a credential but no application
+        // payload; keep the credential paired with content so consumers see it
+        // only on actual messages.
+        let credential = content.as_ref().and(credential);
         Ok(ConvoOutcome {
             convo_id: self.id().to_string(),
             content,
-            sender,
+            credential,
         })
     }
 

--- a/core/conversations/src/conversation/group_v1.rs
+++ b/core/conversations/src/conversation/group_v1.rs
@@ -12,7 +12,7 @@ use openmls::prelude::*;
 use prost::Message as _;
 use shared_traits::IdentIdRef;
 
-use crate::account_directory::{AccountDirectory, resolve_device_ids};
+use crate::account_service::{AccountService, resolve_device_ids};
 use crate::inbox_v2::MlsProvider;
 use crate::service_context::{ExternalServices, ServiceContext};
 
@@ -149,7 +149,7 @@ impl GroupV1Convo {
         &self,
         ident: IdentIdRef,
         provider: &impl MlsProvider,
-        registry: &(impl KeyPackageProvider + AccountDirectory),
+        registry: &(impl KeyPackageProvider + AccountService),
     ) -> Result<Vec<KeyPackage>, ChatError> {
         let device_ids =
             resolve_device_ids(registry, ident).map_err(|e| ChatError::Generic(e.to_string()))?;

--- a/core/conversations/src/conversation/group_v2.rs
+++ b/core/conversations/src/conversation/group_v2.rs
@@ -21,7 +21,7 @@ use de_mls::protos::de_mls::messages::v1::{
 };
 use de_mls::session::{Conversation, ConversationConfig, ConversationDeps};
 use hashgraph_like_consensus::signing::EthereumConsensusSigner;
-use logos_account::MessageSender;
+use logos_account::SenderCredential;
 use prost::Message;
 use shared_traits::{IdentId, IdentIdRef};
 use std::sync::Arc;
@@ -464,10 +464,11 @@ impl GroupV2Convo {
                 // de-mls carries only the sender's member-id (the LocalIdentity
                 // display string); it does not yet expose an account-bound
                 // credential the way GroupV1 does. Surface the LocalIdentity and
-                // treat it as its own Account (the testnet 1:1 case).
-                // TODO: resolve the Account once de-mls exposes the sender
-                // credential, mirroring GroupV1Convo::resolve_sender.
-                sender: Some(MessageSender {
+                // claim it as its own Account (the testnet 1:1 case). This claim
+                // won't validate against the account directory, so the client
+                // reports it unverified.
+                // TODO: surface a real credential once de-mls exposes the sender.
+                credential: Some(SenderCredential {
                     account: IdentId::new(cm.sender.clone()),
                     local_identity: IdentId::new(cm.sender.clone()),
                 }),

--- a/core/conversations/src/conversation/group_v2.rs
+++ b/core/conversations/src/conversation/group_v2.rs
@@ -21,6 +21,7 @@ use de_mls::protos::de_mls::messages::v1::{
 };
 use de_mls::session::{Conversation, ConversationConfig, ConversationDeps};
 use hashgraph_like_consensus::signing::EthereumConsensusSigner;
+use logos_account::MessageSender;
 use prost::Message;
 use shared_traits::{IdentId, IdentIdRef};
 use std::sync::Arc;
@@ -459,6 +460,16 @@ impl GroupV2Convo {
                 convo_id: self.convo_id.clone(),
                 content: Some(Content {
                     bytes: cm.message.clone(),
+                }),
+                // de-mls carries only the sender's member-id (the LocalIdentity
+                // display string); it does not yet expose an account-bound
+                // credential the way GroupV1 does. Surface the LocalIdentity and
+                // treat it as its own Account (the testnet 1:1 case).
+                // TODO: resolve the Account once de-mls exposes the sender
+                // credential, mirroring GroupV1Convo::resolve_sender.
+                sender: Some(MessageSender {
+                    account: IdentId::new(cm.sender.clone()),
+                    local_identity: IdentId::new(cm.sender.clone()),
                 }),
             }),
             _ => None,

--- a/core/conversations/src/conversation/group_v2.rs
+++ b/core/conversations/src/conversation/group_v2.rs
@@ -17,7 +17,8 @@ use de_mls::defaults::{
 use de_mls::member_id::MemberId;
 use de_mls::mls_crypto::MlsCredentials;
 use de_mls::protos::de_mls::messages::v1::{
-    AppMessage as AppMessageProto, MemberWelcome, app_message,
+    AppMessage as AppMessageProto, ConversationMessage as ConversationMessageProto, MemberWelcome,
+    app_message,
 };
 use de_mls::session::{Conversation, ConversationConfig, ConversationDeps};
 use hashgraph_like_consensus::signing::EthereumConsensusSigner;
@@ -461,21 +462,34 @@ impl GroupV2Convo {
                 content: Some(Content {
                     bytes: cm.message.clone(),
                 }),
-                // de-mls carries only the sender's member-id (the LocalIdentity
-                // display string); it does not yet expose an account-bound
-                // credential the way GroupV1 does. Surface the LocalIdentity and
-                // claim it as its own Account (the testnet 1:1 case). This claim
-                // won't validate against the account directory, so the client
-                // reports it unverified.
-                // TODO: surface a real credential once de-mls exposes the sender.
-                credential: Some(SenderCredential {
-                    account: IdentId::new(cm.sender.clone()),
-                    local_identity: IdentId::new(cm.sender.clone()),
-                }),
+                // Use the MLS-authenticated sender de-mls stamps on inbound (the
+                // verified leaf credential content), not the self-declared
+                // `sender` string. Today the de-mls member-id is the identity
+                // *name*, so account == local identity (the single-key testnet
+                // case) and it won't validate against the account directory (a
+                // name isn't an account key) — the client reports it unverified.
+                // TODO: once the member-id carries an account key, this becomes a
+                // directory-validated credential like GroupV1.
+                credential: sender_credential(cm),
             }),
             _ => None,
         })
     }
+}
+
+/// Build a [`SenderCredential`] from de-mls's MLS-authenticated `sender_credential`
+/// (the verified member-id bytes stamped on inbound). Returns `None` when de-mls
+/// didn't stamp one (e.g. system messages). The member-id is the identity name
+/// today, so account and local identity are the same.
+fn sender_credential(cm: &ConversationMessageProto) -> Option<SenderCredential> {
+    if cm.sender_credential.is_empty() {
+        return None;
+    }
+    let id = IdentId::new(String::from_utf8_lossy(&cm.sender_credential).into_owned());
+    Some(SenderCredential {
+        account: id.clone(),
+        local_identity: id,
+    })
 }
 
 use prost::{Oneof, bytes::Bytes};

--- a/core/conversations/src/conversation/privatev1.rs
+++ b/core/conversations/src/conversation/privatev1.rs
@@ -273,6 +273,8 @@ impl<S: ExternalServices> Convo<S> for PrivateV1Convo {
         Ok(ConvoOutcome {
             convo_id: self.id().to_string(),
             content,
+            // TODO: surface the peer identity for 1:1 conversations.
+            sender: None,
         })
     }
 

--- a/core/conversations/src/conversation/privatev1.rs
+++ b/core/conversations/src/conversation/privatev1.rs
@@ -273,8 +273,8 @@ impl<S: ExternalServices> Convo<S> for PrivateV1Convo {
         Ok(ConvoOutcome {
             convo_id: self.id().to_string(),
             content,
-            // TODO: surface the peer identity for 1:1 conversations.
-            sender: None,
+            // TODO: surface the peer credential for 1:1 conversations.
+            credential: None,
         })
     }
 

--- a/core/conversations/src/core.rs
+++ b/core/conversations/src/core.rs
@@ -1,7 +1,10 @@
 use crate::causal_history::{CausalHistoryStore, MissingMessage};
 use crate::conversation::{ConversationIdRef, GroupV1Convo, GroupV2Convo, PrivateV1Convo};
 use crate::service_context::{ExternalServices, ServiceContext};
-use crate::{DeliveryService, IdentityProvider, RegistrationService, WakeupService};
+use crate::{
+    AccountService, DeliveryService, IdentityProvider, MessageSender, RegistrationService,
+    SenderCredential, WakeupService,
+};
 use crate::{
     conversation::{Convo, GroupConvo},
     errors::ChatError,
@@ -10,7 +13,7 @@ use crate::{
     outcomes::{ConvoOutcome, InboxOutcome, PayloadOutcome},
     proto::{EncryptedPayload, EnvelopeV1, Message},
 };
-use crypto::{Identity, PublicKey};
+use crypto::{Ed25519VerifyingKey, Identity, PublicKey};
 use openmls::group::GroupId;
 use shared_traits::IdentIdRef;
 use std::collections::HashMap;
@@ -292,6 +295,32 @@ impl<'a, S: ExternalServices + 'static> Core<S> {
         self.services.causal.take_missing()
     }
 
+    /// Validate a [`SenderCredential`] against the account → device directory.
+    ///
+    /// This is the trust step the credential's account *claim* is checked
+    /// against: if the device key is a registered LocalIdentity of the claimed
+    /// account, returns the confirmed [`MessageSender`] identifier. `Ok(None)`
+    /// means the claim could not be confirmed — unknown account, unregistered
+    /// device, or a non-key identifier (e.g. a de-mls member id that isn't an
+    /// account key).
+    pub fn validate_sender(
+        &self,
+        cred: &SenderCredential,
+    ) -> Result<Option<MessageSender>, ChatError> {
+        let (Some(account), Some(device)) = (
+            key_from_hex(cred.account.as_str()),
+            key_from_hex(cred.local_identity.as_str()),
+        ) else {
+            return Ok(None);
+        };
+        let valid = self
+            .services
+            .registry
+            .is_local_identity_of(&account, &device)
+            .map_err(|e| ChatError::Generic(e.to_string()))?;
+        Ok(valid.then(|| MessageSender::validated(cred.clone())))
+    }
+
     /// Encrypt and publish `content` to an existing conversation.
     pub fn send_content(&mut self, convo_id: &str, content: &[u8]) -> Result<(), ChatError> {
         if self.cached_convos.contains_key(convo_id) {
@@ -462,6 +491,13 @@ impl<'a, S: ExternalServices + 'static> Core<S> {
             .load_conversation(convo_id)?
             .ok_or_else(|| ChatError::NoConvo(convo_id.into()))
     }
+}
+
+/// Parse a hex-encoded Ed25519 verifying key, as carried in a
+/// [`SenderCredential`]'s ids. Returns `None` for non-key identifiers.
+fn key_from_hex(s: &str) -> Option<Ed25519VerifyingKey> {
+    let bytes: [u8; 32] = hex::decode(s).ok()?.try_into().ok()?;
+    Ed25519VerifyingKey::from_bytes(&bytes).ok()
 }
 
 #[derive(Debug)]

--- a/core/conversations/src/inbox_v2.rs
+++ b/core/conversations/src/inbox_v2.rs
@@ -205,14 +205,10 @@ impl InboxV2 {
             .ciphersuites(vec![CIPHER_SUITE])
             .extensions(vec![ExtensionType::ApplicationId])
             .build();
+        let credential = cx.mls_identity.get_credential()?;
         let a = KeyPackage::builder()
             .leaf_node_capabilities(capabilities)
-            .build(
-                CIPHER_SUITE,
-                &cx.mls_provider,
-                &cx.mls_identity,
-                cx.mls_identity.get_credential(),
-            )
+            .build(CIPHER_SUITE, &cx.mls_provider, &cx.mls_identity, credential)
             .expect("Failed to build KeyPackage");
 
         Ok(a.key_package().clone())

--- a/core/conversations/src/inbox_v2.rs
+++ b/core/conversations/src/inbox_v2.rs
@@ -24,8 +24,7 @@ use crate::conversation::GroupV2Convo;
 use crate::service_context::{ExternalServices, ServiceContext};
 use crate::utils::{blake2b_hex, hash_size};
 use crate::{
-    AccountAuthority, AccountDirectory, AddressedEnvelope, SignedDeviceBundle,
-    encode_bundle_payload,
+    AccountAuthority, AccountService, AddressedEnvelope, SignedDeviceBundle, encode_bundle_payload,
 };
 use crate::{IdentId, IdentIdRef, IdentityProvider};
 
@@ -216,7 +215,7 @@ impl InboxV2 {
 }
 
 // Publishing the account → device bundle needs the account key, so this method
-// is available only when the registry also implements `AccountDirectory`. The
+// is available only when the registry also implements `AccountService`. The
 // signing authority is the `LogosAccount` wrapped by `mls_identity`; on testnet
 // that is a local key (account key == device key), while an external signer
 // would supply its own authority.

--- a/core/conversations/src/inbox_v2/identity.rs
+++ b/core/conversations/src/inbox_v2/identity.rs
@@ -26,19 +26,15 @@ impl<T: IdentityProvider> MlsIdentityProvider<T> {
 
     /// Build the MLS leaf credential for this identity.
     ///
-    /// The credential content binds this device (LocalIdentity) to its Account:
-    /// the leaf's signature key is the device key, and the content carries the
-    /// Account key plus the Account's endorsement of that device key. A receiver
-    /// recovers both via [`logos_account::resolve_sender`]. On testnet the
-    /// account key *is* the device key, so the endorsement is self-signed.
+    /// The credential is a plain claim: its content carries the **Account** key,
+    /// and the leaf's signature key is the **device** (LocalIdentity) key. A
+    /// receiver decodes both via [`logos_account::decode_credential`] and must
+    /// validate the account claim against an
+    /// [`AccountService`](logos_account::AccountService) before trusting it.
     pub fn get_credential(&self) -> Result<CredentialWithKey, ChatError> {
         let account = AccountAuthority::account_pub(self).clone();
         let device = self.public_key().clone();
-        let endorsement = logos_account::endorse_local_identity(&account, &device, |msg| {
-            AccountAuthority::sign(self, msg)
-        })
-        .map_err(|e| ChatError::Generic(e.to_string()))?;
-        let content = logos_account::encode_credential(&account, &endorsement);
+        let content = logos_account::encode_credential(&account);
         Ok(CredentialWithKey {
             credential: BasicCredential::new(content).into(),
             signature_key: device.as_ref().into(),

--- a/core/conversations/src/inbox_v2/identity.rs
+++ b/core/conversations/src/inbox_v2/identity.rs
@@ -9,6 +9,7 @@ use openmls_traits::{
 use shared_traits::IdentIdRef;
 
 use crate::AccountAuthority;
+use crate::ChatError;
 use crate::IdentityProvider;
 
 /// A Wrapper for an IdentityProvider which provides MLS specific functionality
@@ -23,11 +24,25 @@ impl<T: IdentityProvider> MlsIdentityProvider<T> {
         Self(inner)
     }
 
-    pub fn get_credential(&self) -> CredentialWithKey {
-        CredentialWithKey {
-            credential: BasicCredential::new(self.id().as_str().as_bytes().to_vec()).into(),
-            signature_key: self.public_key().as_ref().into(),
-        }
+    /// Build the MLS leaf credential for this identity.
+    ///
+    /// The credential content binds this device (LocalIdentity) to its Account:
+    /// the leaf's signature key is the device key, and the content carries the
+    /// Account key plus the Account's endorsement of that device key. A receiver
+    /// recovers both via [`logos_account::resolve_sender`]. On testnet the
+    /// account key *is* the device key, so the endorsement is self-signed.
+    pub fn get_credential(&self) -> Result<CredentialWithKey, ChatError> {
+        let account = AccountAuthority::account_pub(self).clone();
+        let device = self.public_key().clone();
+        let endorsement = logos_account::endorse_local_identity(&account, &device, |msg| {
+            AccountAuthority::sign(self, msg)
+        })
+        .map_err(|e| ChatError::Generic(e.to_string()))?;
+        let content = logos_account::encode_credential(&account, &endorsement);
+        Ok(CredentialWithKey {
+            credential: BasicCredential::new(content).into(),
+            signature_key: device.as_ref().into(),
+        })
     }
 }
 

--- a/core/conversations/src/lib.rs
+++ b/core/conversations/src/lib.rs
@@ -14,8 +14,8 @@ mod types;
 mod utils;
 
 pub use account_directory::{
-    AccountAuthority, AccountDirectory, BUNDLE_VERSION, BundleError, DecodedBundle, DeviceId,
-    DeviceSet, Lamport, SignedDeviceBundle, decode_bundle_payload, encode_bundle_payload,
+    AccountAuthority, AccountDirectory, AccountService, BUNDLE_VERSION, BundleError, DecodedBundle,
+    DeviceId, DeviceSet, Lamport, SignedDeviceBundle, decode_bundle_payload, encode_bundle_payload,
     resolve_device_ids, verify_bundle,
 };
 pub use causal_history::{Frontier, MissingMessage};
@@ -23,7 +23,7 @@ pub use chat_sqlite::ChatStorage;
 pub use chat_sqlite::StorageConfig;
 pub use core::{ConversationId, Core, Introduction};
 pub use errors::ChatError;
-pub use logos_account::MessageSender;
+pub use logos_account::{MessageSender, SenderCredential};
 pub use outcomes::{
     Content, ConversationClass, ConvoOutcome, InboxOutcome, NewConversation, PayloadOutcome,
 };

--- a/core/conversations/src/lib.rs
+++ b/core/conversations/src/lib.rs
@@ -23,6 +23,7 @@ pub use chat_sqlite::ChatStorage;
 pub use chat_sqlite::StorageConfig;
 pub use core::{ConversationId, Core, Introduction};
 pub use errors::ChatError;
+pub use logos_account::MessageSender;
 pub use outcomes::{
     Content, ConversationClass, ConvoOutcome, InboxOutcome, NewConversation, PayloadOutcome,
 };

--- a/core/conversations/src/lib.rs
+++ b/core/conversations/src/lib.rs
@@ -1,4 +1,4 @@
-mod account_directory;
+mod account_service;
 mod causal_history;
 mod conversation;
 mod core;
@@ -13,9 +13,9 @@ mod service_traits;
 mod types;
 mod utils;
 
-pub use account_directory::{
-    AccountAuthority, AccountDirectory, AccountService, BUNDLE_VERSION, BundleError, DecodedBundle,
-    DeviceId, DeviceSet, Lamport, SignedDeviceBundle, decode_bundle_payload, encode_bundle_payload,
+pub use account_service::{
+    AccountAuthority, AccountService, BUNDLE_VERSION, BundleError, DecodedBundle, DeviceId,
+    DeviceSet, Lamport, SignedDeviceBundle, decode_bundle_payload, encode_bundle_payload,
     resolve_device_ids, verify_bundle,
 };
 pub use causal_history::{Frontier, MissingMessage};

--- a/core/conversations/src/outcomes.rs
+++ b/core/conversations/src/outcomes.rs
@@ -20,12 +20,6 @@ pub struct Content {
 pub struct ConvoOutcome {
     pub convo_id: ConversationId,
     pub content: Option<Content>,
-    /// The *unvalidated* sender credential for `content`: the claimed Account
-    /// and the device (LocalIdentity) it was sent from. The device key is
-    /// MLS-authenticated, but the account claim must be validated against an
-    /// [`AccountService`](logos_account::AccountService) before it is trusted.
-    /// `None` for control messages (e.g. MLS commits) carrying no application
-    /// content, and for conversation types that don't yet surface a credential.
     pub credential: Option<SenderCredential>,
 }
 

--- a/core/conversations/src/outcomes.rs
+++ b/core/conversations/src/outcomes.rs
@@ -6,7 +6,7 @@
 //!   initial [`ConvoOutcome`].
 //! - [`PayloadOutcome`] — the union of the above, plus `Empty`.
 
-use logos_account::MessageSender;
+use logos_account::SenderCredential;
 use storage::ConversationKind;
 
 use crate::conversation::ConversationId;
@@ -20,11 +20,13 @@ pub struct Content {
 pub struct ConvoOutcome {
     pub convo_id: ConversationId,
     pub content: Option<Content>,
-    /// The verified sender of `content`: both the Account and the specific
-    /// LocalIdentity (device) it was sent from. `None` for control messages
-    /// (e.g. MLS commits) that carry no application content, and for
-    /// conversation types that don't yet surface a sender.
-    pub sender: Option<MessageSender>,
+    /// The *unvalidated* sender credential for `content`: the claimed Account
+    /// and the device (LocalIdentity) it was sent from. The device key is
+    /// MLS-authenticated, but the account claim must be validated against an
+    /// [`AccountService`](logos_account::AccountService) before it is trusted.
+    /// `None` for control messages (e.g. MLS commits) carrying no application
+    /// content, and for conversation types that don't yet surface a credential.
+    pub credential: Option<SenderCredential>,
 }
 
 impl ConvoOutcome {
@@ -32,7 +34,7 @@ impl ConvoOutcome {
         Self {
             convo_id,
             content: None,
-            sender: None,
+            credential: None,
         }
     }
 }

--- a/core/conversations/src/outcomes.rs
+++ b/core/conversations/src/outcomes.rs
@@ -6,6 +6,7 @@
 //!   initial [`ConvoOutcome`].
 //! - [`PayloadOutcome`] — the union of the above, plus `Empty`.
 
+use logos_account::MessageSender;
 use storage::ConversationKind;
 
 use crate::conversation::ConversationId;
@@ -19,6 +20,11 @@ pub struct Content {
 pub struct ConvoOutcome {
     pub convo_id: ConversationId,
     pub content: Option<Content>,
+    /// The verified sender of `content`: both the Account and the specific
+    /// LocalIdentity (device) it was sent from. `None` for control messages
+    /// (e.g. MLS commits) that carry no application content, and for
+    /// conversation types that don't yet surface a sender.
+    pub sender: Option<MessageSender>,
 }
 
 impl ConvoOutcome {
@@ -26,6 +32,7 @@ impl ConvoOutcome {
         Self {
             convo_id,
             content: None,
+            sender: None,
         }
     }
 }

--- a/core/conversations/src/service_context.rs
+++ b/core/conversations/src/service_context.rs
@@ -49,7 +49,7 @@ pub(crate) struct ServiceContext<S: ExternalServices> {
 #[cfg(test)]
 mod test_support {
     use super::*;
-    use crate::account_directory::{AccountDirectory, DeviceSet, SignedDeviceBundle};
+    use crate::account_service::{AccountService, DeviceSet, SignedDeviceBundle};
     use crate::types::AddressedEnvelope;
     use crate::{ChatError, IdentityProvider};
     use crypto::Ed25519VerifyingKey;
@@ -93,20 +93,20 @@ mod test_support {
         }
     }
 
-    impl AccountDirectory for NoopRegistration {
+    impl AccountService for NoopRegistration {
         type Error = std::convert::Infallible;
 
         fn publish(
             &mut self,
             _bundle: &SignedDeviceBundle,
-        ) -> Result<(), <Self as AccountDirectory>::Error> {
+        ) -> Result<(), <Self as AccountService>::Error> {
             Ok(())
         }
 
         fn fetch(
             &self,
             _account: &Ed25519VerifyingKey,
-        ) -> Result<Option<DeviceSet>, <Self as AccountDirectory>::Error> {
+        ) -> Result<Option<DeviceSet>, <Self as AccountService>::Error> {
             Ok(None)
         }
     }

--- a/core/conversations/src/service_traits.rs
+++ b/core/conversations/src/service_traits.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use crate::{AccountDirectory, ConversationId, types::AddressedEnvelope};
+use crate::{AccountService, ConversationId, types::AddressedEnvelope};
 
 /// A Delivery service is responsible for payload transport.
 /// This interface allows Conversations to send payloads on the wire as well as
@@ -30,13 +30,13 @@ pub trait DeliveryService: Debug {
 /// service that verifies the bundle is signed by the correct account — can
 /// sign or attest with the caller's key material.
 ///
-/// On testnet a single service (the keypackage-registry) provides both the
-/// keypackage store and the account → device directory, so [`AccountDirectory`]
-/// is a supertrait: any `RegistrationService` also resolves accounts to devices.
-/// This co-location is intentional and temporary; the two can be split into
-/// separate injected services once λLEZ lands.
-pub trait RegistrationService: Debug + AccountDirectory {
-    // Disambiguated below: with `AccountDirectory` as a supertrait, a bare
+/// On testnet a single service (chat-store) provides both the keypackage store
+/// and the account service, so [`AccountService`] is a supertrait: any
+/// `RegistrationService` also resolves accounts to devices. This co-location is
+/// intentional and temporary; the two can be split into separate injected
+/// services once λLEZ lands.
+pub trait RegistrationService: Debug + AccountService {
+    // Disambiguated below: with `AccountService` as a supertrait, a bare
     // `Self::Error` is ambiguous between the two traits' associated types.
     type Error: Display + Debug;
     fn register(
@@ -58,7 +58,7 @@ pub trait KeyPackageProvider: Debug {
 }
 
 impl<T: RegistrationService> KeyPackageProvider for T {
-    // Disambiguate: `RegistrationService` now has `AccountDirectory` as a
+    // Disambiguate: `RegistrationService` now has `AccountService` as a
     // supertrait, so both expose an associated `Error`.
     type Error = <T as RegistrationService>::Error;
     fn retrieve(&self, device_id: &str) -> Result<Option<Vec<u8>>, Self::Error> {

--- a/core/integration_tests_core/src/test_client.rs
+++ b/core/integration_tests_core/src/test_client.rs
@@ -75,10 +75,16 @@ impl TestClient {
                             content = String::from_utf8_lossy(&data.bytes).to_string(),
                             "COT"
                         );
+                        // Validate the raw credential against the account
+                        // directory, exactly as the client does.
+                        let sender = convo_outcome
+                            .credential
+                            .as_ref()
+                            .and_then(|c| self.inner.validate_sender(c).ok().flatten());
                         self.received_messages.push(ReceivedMessage {
                             convo_id: convo_outcome.convo_id.clone(),
                             contents: data.bytes.clone(),
-                            sender: convo_outcome.sender.clone(),
+                            sender,
                         });
                     }
                 }

--- a/core/integration_tests_core/src/test_client.rs
+++ b/core/integration_tests_core/src/test_client.rs
@@ -1,4 +1,4 @@
-use libchat::{ConversationId, Core, IdentityProvider, PayloadOutcome};
+use libchat::{ConversationId, Core, IdentityProvider, MessageSender, PayloadOutcome};
 use logos_account::TestLogosAccount;
 use shared_traits::IdentId;
 use std::collections::HashMap;
@@ -34,6 +34,8 @@ type ClientType = Core<(
 pub struct ReceivedMessage<T> {
     pub convo_id: ConversationId,
     pub contents: T,
+    /// The verified sender (Account + LocalIdentity) surfaced with the message.
+    pub sender: Option<MessageSender>,
 }
 
 pub struct TestClient {
@@ -76,6 +78,7 @@ impl TestClient {
                         self.received_messages.push(ReceivedMessage {
                             convo_id: convo_outcome.convo_id.clone(),
                             contents: data.bytes.clone(),
+                            sender: convo_outcome.sender.clone(),
                         });
                     }
                 }
@@ -100,6 +103,15 @@ impl TestClient {
             }
         }
         false
+    }
+
+    /// The verified sender recorded for the (first) message matching
+    /// `convo_id`/`content`, if any was received.
+    pub fn sender_of(&self, convo_id: &str, content: &[u8]) -> Option<&MessageSender> {
+        self.received_messages
+            .iter()
+            .find(|m| m.convo_id == convo_id && m.contents == content)
+            .and_then(|m| m.sender.as_ref())
     }
 
     pub fn convo_count(&self) -> usize {

--- a/core/integration_tests_core/src/test_client.rs
+++ b/core/integration_tests_core/src/test_client.rs
@@ -41,18 +41,24 @@ pub struct ReceivedMessage<T> {
 pub struct TestClient {
     inner: ClientType,
     received_messages: Vec<ReceivedMessage<Vec<u8>>>,
+    sender_identity: MessageSender,
 }
 
 impl TestClient {
-    fn init(client: ClientType) -> Self {
+    fn init(client: ClientType, sender_identity: MessageSender) -> Self {
         Self {
             inner: client,
             received_messages: vec![],
+            sender_identity,
         }
     }
 
     pub fn addr(&self) -> IdentId {
         self.inner.ident_id().clone()
+    }
+
+    pub fn as_sender(&self) -> MessageSender {
+        self.sender_identity.clone()
     }
 
     fn drain_outcomes(&mut self) -> Vec<PayloadOutcome> {
@@ -102,9 +108,9 @@ impl TestClient {
         &self.received_messages
     }
 
-    pub fn check(&self, convo_id: &str, content: &[u8]) -> bool {
+    pub fn check(&self, convo_id: &str, content: &[u8], sender: Option<MessageSender>) -> bool {
         for msg in &self.received_messages {
-            if msg.convo_id == convo_id && msg.contents == content {
+            if msg.convo_id == convo_id && msg.contents == content && msg.sender == sender {
                 return true;
             }
         }
@@ -172,11 +178,16 @@ impl<const N: usize> TestHarness<N> {
             let ident = TestLogosAccount::new(Self::names(i));
 
             addresses.insert(i, ident.id().clone());
+            let iden_id = ident.iden_id();
+            let sender_identity = MessageSender {
+                account: iden_id.clone(),
+                local_identity: iden_id,
+            };
             let core_client =
                 ClientType::new_with_name(ident, ds.clone(), rs.clone(), wp, MemStore::new())
                     .unwrap();
 
-            let client = TestClient::init(core_client);
+            let client = TestClient::init(core_client, sender_identity);
 
             clients.push(client);
         }
@@ -348,6 +359,8 @@ mod tests {
 
         harness.process(Duration::from_millis(200));
 
-        assert!(harness.raya().check(&convo_id, b"Hello"))
+        // GroupV2 (de-mls) carries no account-bound credential yet, so the
+        // sender can't be validated — it resolves to `None`.
+        assert!(harness.raya().check(&convo_id, b"Hello", None))
     }
 }

--- a/core/integration_tests_core/tests/mls_integration.rs
+++ b/core/integration_tests_core/tests/mls_integration.rs
@@ -57,4 +57,30 @@ fn create_group() {
 
     assert!(!harness.pax().check(&convo_id, M_R1));
     assert!(!harness.pax().check(&convo_id, M_P1));
+
+    // Every delivered message carries a verified sender: both the Account and
+    // the LocalIdentity it was sent from. On testnet each identity is its own
+    // single-device account, so the two resolve to the same key.
+    let raya_sender = harness
+        .saro()
+        .sender_of(&convo_id, M_R1)
+        .expect("Saro should see who sent Raya's message")
+        .clone();
+    assert_eq!(
+        raya_sender.account, raya_sender.local_identity,
+        "single-key testnet account resolves Account == LocalIdentity"
+    );
+
+    let pax_sender = harness
+        .saro()
+        .sender_of(&convo_id, M_P1)
+        .expect("Saro should see who sent Pax's message")
+        .clone();
+
+    // Distinct identities resolve to distinct senders — the basis for telling
+    // group members apart and for collapsing an account's devices to one Account.
+    assert_ne!(
+        raya_sender.account, pax_sender.account,
+        "Raya and Pax must resolve to different accounts"
+    );
 }

--- a/core/integration_tests_core/tests/mls_integration.rs
+++ b/core/integration_tests_core/tests/mls_integration.rs
@@ -61,17 +61,33 @@ fn create_group() {
             .saro()
             .check(&convo_id, M_R1, Some(raya_sender.clone()))
     );
-    assert!(harness.saro().check(&convo_id, M_P1, Some(pax_sender.clone())));
+    assert!(
+        harness
+            .saro()
+            .check(&convo_id, M_P1, Some(pax_sender.clone()))
+    );
 
     assert!(
         !harness
             .raya()
             .check(&convo_id, M_R1, Some(raya_sender.clone()))
     );
-    assert!(harness.raya().check(&convo_id, M_P1, Some(pax_sender.clone())));
+    assert!(
+        harness
+            .raya()
+            .check(&convo_id, M_P1, Some(pax_sender.clone()))
+    );
 
-    assert!(!harness.pax().check(&convo_id, M_R1, Some(raya_sender.clone())));
-    assert!(!harness.pax().check(&convo_id, M_P1, Some(pax_sender.clone())));
+    assert!(
+        !harness
+            .pax()
+            .check(&convo_id, M_R1, Some(raya_sender.clone()))
+    );
+    assert!(
+        !harness
+            .pax()
+            .check(&convo_id, M_P1, Some(pax_sender.clone()))
+    );
 
     // Single-key testnet account: account and local identity are the same key.
     assert_eq!(

--- a/core/integration_tests_core/tests/mls_integration.rs
+++ b/core/integration_tests_core/tests/mls_integration.rs
@@ -49,35 +49,36 @@ fn create_group() {
         .expect("Pax send");
     harness.process(Duration::from_millis(500));
 
-    assert!(harness.saro().check(&convo_id, M_R1));
-    assert!(harness.saro().check(&convo_id, M_P1));
+    // The sender a recipient resolves each author to — the key-based identity,
+    // captured from the account (not the display name in `ident_id`).
+    let raya_sender = harness.raya().as_sender();
+    let pax_sender = harness.pax().as_sender();
 
-    assert!(!harness.raya().check(&convo_id, M_R1));
-    assert!(harness.raya().check(&convo_id, M_P1));
+    // Each message must arrive *and* carry the validated sender of its author:
+    // M_R1 from Raya, M_P1 from Pax.
+    assert!(
+        harness
+            .saro()
+            .check(&convo_id, M_R1, Some(raya_sender.clone()))
+    );
+    assert!(harness.saro().check(&convo_id, M_P1, Some(pax_sender.clone())));
 
-    assert!(!harness.pax().check(&convo_id, M_R1));
-    assert!(!harness.pax().check(&convo_id, M_P1));
+    assert!(
+        !harness
+            .raya()
+            .check(&convo_id, M_R1, Some(raya_sender.clone()))
+    );
+    assert!(harness.raya().check(&convo_id, M_P1, Some(pax_sender.clone())));
 
-    // Every delivered message carries a verified sender: both the Account and
-    // the LocalIdentity it was sent from. On testnet each identity is its own
-    // single-device account, so the two resolve to the same key.
-    let raya_sender = harness
-        .saro()
-        .sender_of(&convo_id, M_R1)
-        .expect("Saro should see who sent Raya's message")
-        .clone();
+    assert!(!harness.pax().check(&convo_id, M_R1, Some(raya_sender.clone())));
+    assert!(!harness.pax().check(&convo_id, M_P1, Some(pax_sender.clone())));
+
+    // Single-key testnet account: account and local identity are the same key.
     assert_eq!(
         raya_sender.account, raya_sender.local_identity,
         "single-key testnet account resolves Account == LocalIdentity"
     );
-
-    let pax_sender = harness
-        .saro()
-        .sender_of(&convo_id, M_P1)
-        .expect("Saro should see who sent Pax's message")
-        .clone();
-
-    // Distinct identities resolve to distinct senders — the basis for telling
+    // Distinct identities resolve to distinct accounts — the basis for telling
     // group members apart and for collapsing an account's devices to one Account.
     assert_ne!(
         raya_sender.account, pax_sender.account,

--- a/core/integration_tests_core/tests/test_group_v2.rs
+++ b/core/integration_tests_core/tests/test_group_v2.rs
@@ -32,12 +32,12 @@ fn groupv2_2way_roundtrip() {
         .send_content(&convo_id, S_M1)
         .expect("saro send");
 
-    harness.process_until(|h| h.raya().check(&convo_id, S_M1));
+    harness.process_until(|h| h.raya().check(&convo_id, S_M1, None));
 
     // Raya replies; settle until Saro receives it.
     info!(target: "chat", "Raya -> sending:{R_M1:?}");
     harness.raya().send_content(&convo_id, R_M1).unwrap();
-    harness.process_until(|h| h.saro().check(&convo_id, R_M1));
+    harness.process_until(|h| h.saro().check(&convo_id, R_M1, None));
 }
 
 #[test]
@@ -70,7 +70,7 @@ fn core_client() {
         .send_content(&convo_id, S_M1)
         .expect("saro send");
 
-    harness.process_until_label("Recv S_M1", |h| h.raya().check(&convo_id, S_M1));
+    harness.process_until_label("Recv S_M1", |h| h.raya().check(&convo_id, S_M1, None));
 
     // Raya replies; settle until Saro receives it.
     info!(target: "chat", "Raya -> sending: {R_M1:?}");
@@ -79,7 +79,7 @@ fn core_client() {
         .send_content(&convo_id, R_M1)
         .expect("raya send");
 
-    harness.process_until_label("Recv R_M1", |h| h.saro().check(&convo_id, R_M1));
+    harness.process_until_label("Recv R_M1", |h| h.saro().check(&convo_id, R_M1, None));
 
     // Raya (a non-creator) invites Pax; settle until Pax has joined.
     let particpants = &[&harness.pax().addr()];
@@ -96,7 +96,7 @@ fn core_client() {
     harness.saro().send_content(&convo_id, S_M2).unwrap();
 
     harness.process_until_label("epoch check", |h| {
-        h.raya().check(&convo_id, S_M2) && h.pax().check(&convo_id, S_M2)
+        h.raya().check(&convo_id, S_M2, None) && h.pax().check(&convo_id, S_M2, None)
     });
 }
 
@@ -171,8 +171,8 @@ fn core_client_four_members_two_epochs() {
         .expect("Saro send");
 
     harness.process_until_label("all chats converge", |h| {
-        h.raya().check(&convo_id, MSG)
-            && h.pax().check(&convo_id, MSG)
-            && h.mira().check(&convo_id, MSG)
+        h.raya().check(&convo_id, MSG, None)
+            && h.pax().check(&convo_id, MSG, None)
+            && h.mira().check(&convo_id, MSG, None)
     });
 }

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -261,11 +261,16 @@ fn events_from_inbound(result: PayloadOutcome) -> Vec<Event> {
 }
 
 fn convo_events(outcome: ConvoOutcome) -> Vec<Event> {
-    let ConvoOutcome { convo_id, content } = outcome;
+    let ConvoOutcome {
+        convo_id,
+        content,
+        sender,
+    } = outcome;
     content
         .map(|c| Event::MessageReceived {
             convo_id: Arc::from(convo_id),
             content: c.bytes,
+            sender,
         })
         .into_iter()
         .collect()
@@ -282,10 +287,13 @@ fn inbox_events(outcome: InboxOutcome) -> Vec<Event> {
         convo_id: Arc::clone(&id),
         class: new_conversation.class,
     });
-    if let Some(c) = initial.and_then(|co| co.content) {
+    if let Some(co) = initial
+        && let Some(c) = co.content
+    {
         events.push(Event::MessageReceived {
             convo_id: Arc::clone(&id),
             content: c.bytes,
+            sender: co.sender,
         });
     }
     events

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -5,7 +5,7 @@ use components::{EphemeralRegistry, ThreadedWakeupService, WakeupEvent};
 use crossbeam_channel::{Receiver, Sender, select};
 use libchat::{
     ChatError, ChatStorage, ConversationId, ConvoOutcome, Core, DeliveryService, InboxOutcome,
-    Introduction, PayloadOutcome, RegistrationService, StorageConfig,
+    Introduction, MessageSender, PayloadOutcome, RegistrationService, StorageConfig,
 };
 use logos_account::TestLogosAccount;
 use parking_lot::Mutex;
@@ -220,7 +220,9 @@ fn worker_loop<T, R>(
                 let events = {
                     let mut core = core.lock();
                     match core.handle_payload(&bytes) {
-                        Ok(outcome) => events_from_inbound(outcome),
+                        // Validation of the sender credential reads the account
+                        // directory, so it runs while the core is still locked.
+                        Ok(outcome) => events_from_inbound(&core, outcome),
                         Err(e) => {
                             tracing::warn!("inbound handle_payload failed: {e:?}");
                             vec![Event::InboundError {
@@ -252,23 +254,42 @@ fn worker_loop<T, R>(
 /// observation. For an `Inbox` outcome, [`Event::ConversationStarted`]
 /// precedes the message event. The convo id is wrapped into `Arc<str>` once
 /// per outcome and shared across the events it produces.
-fn events_from_inbound(result: PayloadOutcome) -> Vec<Event> {
+///
+/// `core` is borrowed so the raw sender credential can be validated against the
+/// account directory — turning the claim into a trusted [`MessageSender`].
+fn events_from_inbound<T, R>(core: &ClientCore<T, R>, result: PayloadOutcome) -> Vec<Event>
+where
+    T: DeliveryService + Send + 'static,
+    R: RegistrationService + Send + 'static,
+{
     match result {
         PayloadOutcome::Empty => Vec::new(),
-        PayloadOutcome::Convo(co) => convo_events(co),
-        PayloadOutcome::Inbox(io) => inbox_events(io),
+        PayloadOutcome::Convo(co) => convo_events(core, co),
+        PayloadOutcome::Inbox(io) => inbox_events(core, io),
     }
 }
 
-fn convo_events(outcome: ConvoOutcome) -> Vec<Event> {
-    let ConvoOutcome {
-        convo_id,
-        content,
-        sender,
-    } = outcome;
-    content
+/// Validate the outcome's sender credential against the account service,
+/// yielding the trusted identifier (or `None` when the claim can't be confirmed).
+fn validate<T, R>(core: &ClientCore<T, R>, outcome: &ConvoOutcome) -> Option<MessageSender>
+where
+    T: DeliveryService + Send + 'static,
+    R: RegistrationService + Send + 'static,
+{
+    let cred = outcome.credential.as_ref()?;
+    core.validate_sender(cred).ok().flatten()
+}
+
+fn convo_events<T, R>(core: &ClientCore<T, R>, outcome: ConvoOutcome) -> Vec<Event>
+where
+    T: DeliveryService + Send + 'static,
+    R: RegistrationService + Send + 'static,
+{
+    let sender = validate(core, &outcome);
+    outcome
+        .content
         .map(|c| Event::MessageReceived {
-            convo_id: Arc::from(convo_id),
+            convo_id: Arc::from(outcome.convo_id),
             content: c.bytes,
             sender,
         })
@@ -276,7 +297,11 @@ fn convo_events(outcome: ConvoOutcome) -> Vec<Event> {
         .collect()
 }
 
-fn inbox_events(outcome: InboxOutcome) -> Vec<Event> {
+fn inbox_events<T, R>(core: &ClientCore<T, R>, outcome: InboxOutcome) -> Vec<Event>
+where
+    T: DeliveryService + Send + 'static,
+    R: RegistrationService + Send + 'static,
+{
     let InboxOutcome {
         new_conversation,
         initial,
@@ -287,14 +312,15 @@ fn inbox_events(outcome: InboxOutcome) -> Vec<Event> {
         convo_id: Arc::clone(&id),
         class: new_conversation.class,
     });
-    if let Some(co) = initial
-        && let Some(c) = co.content
-    {
-        events.push(Event::MessageReceived {
-            convo_id: Arc::clone(&id),
-            content: c.bytes,
-            sender: co.sender,
-        });
+    if let Some(co) = initial {
+        let sender = validate(core, &co);
+        if let Some(c) = co.content {
+            events.push(Event::MessageReceived {
+                convo_id: Arc::clone(&id),
+                content: c.bytes,
+                sender,
+            });
+        }
     }
     events
 }

--- a/crates/client/src/event.rs
+++ b/crates/client/src/event.rs
@@ -8,7 +8,7 @@
 
 use std::sync::Arc;
 
-use libchat::ConversationClass;
+use libchat::{ConversationClass, MessageSender};
 
 /// A discrete chat event.
 #[non_exhaustive]
@@ -23,6 +23,10 @@ pub enum Event {
     MessageReceived {
         convo_id: Arc<str>,
         content: Vec<u8>,
+        /// The verified sender — both the Account and the LocalIdentity
+        /// (device) it was sent from. `None` when the conversation type does
+        /// not yet surface a sender.
+        sender: Option<MessageSender>,
     },
     InboundError {
         message: String,

--- a/crates/client/src/event.rs
+++ b/crates/client/src/event.rs
@@ -23,9 +23,6 @@ pub enum Event {
     MessageReceived {
         convo_id: Arc<str>,
         content: Vec<u8>,
-        /// The verified sender — both the Account and the LocalIdentity
-        /// (device) it was sent from. `None` when the conversation type does
-        /// not yet surface a sender.
         sender: Option<MessageSender>,
     },
     InboundError {

--- a/crates/client/tests/saro_and_raya.rs
+++ b/crates/client/tests/saro_and_raya.rs
@@ -37,7 +37,9 @@ fn saro_raya_message_exchange() {
         other => Err(other),
     });
     expect_event(&raya_events, "MessageReceived", |e| match e {
-        Event::MessageReceived { convo_id, content } => {
+        Event::MessageReceived {
+            convo_id, content, ..
+        } => {
             assert_eq!(convo_id, raya_convo_id);
             assert_eq!(content.as_slice(), b"hello raya");
             Ok(())

--- a/extensions/components/src/contact_registry/ephemeral.rs
+++ b/extensions/components/src/contact_registry/ephemeral.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crypto::Ed25519VerifyingKey;
 use libchat::{
-    AccountDirectory, DeviceSet, IdentityProvider, RegistrationService, SignedDeviceBundle,
+    AccountService, DeviceSet, IdentityProvider, RegistrationService, SignedDeviceBundle,
     verify_bundle,
 };
 
@@ -16,7 +16,7 @@ use libchat::{
 ///
 /// Like the real `keypackage-registry`, one object serves both roles: a
 /// keypackage store ([`RegistrationService`]) keyed by `device_id`, and an
-/// account → device directory ([`AccountDirectory`]) keyed by the hex account key.
+/// account service ([`AccountService`]) keyed by the hex account key.
 #[derive(Clone, Default)]
 pub struct EphemeralRegistry {
     key_packages: Arc<Mutex<HashMap<String, Vec<u8>>>>,
@@ -78,13 +78,13 @@ impl RegistrationService for EphemeralRegistry {
 
 /// Account → device directory, verifying each bundle on `fetch` exactly as the
 /// HTTP client does so callers exercise the same trust path without a server.
-impl AccountDirectory for EphemeralRegistry {
+impl AccountService for EphemeralRegistry {
     type Error = String;
 
     fn publish(
         &mut self,
         bundle: &SignedDeviceBundle,
-    ) -> Result<(), <Self as AccountDirectory>::Error> {
+    ) -> Result<(), <Self as AccountService>::Error> {
         self.installations
             .lock()
             .unwrap()
@@ -95,7 +95,7 @@ impl AccountDirectory for EphemeralRegistry {
     fn fetch(
         &self,
         account: &Ed25519VerifyingKey,
-    ) -> Result<Option<DeviceSet>, <Self as AccountDirectory>::Error> {
+    ) -> Result<Option<DeviceSet>, <Self as AccountService>::Error> {
         let Some(bundle) = self
             .installations
             .lock()

--- a/extensions/components/src/contact_registry/http.rs
+++ b/extensions/components/src/contact_registry/http.rs
@@ -5,7 +5,7 @@ use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use crypto::{Ed25519Signature, Ed25519VerifyingKey};
 use libchat::{
-    AccountDirectory, BundleError, DeviceSet, IdentityProvider, RegistrationService,
+    AccountService, BundleError, DeviceSet, IdentityProvider, RegistrationService,
     SignedDeviceBundle, verify_bundle,
 };
 use serde::{Deserialize, Serialize};
@@ -179,7 +179,7 @@ impl RegistrationService for HttpRegistry {
     }
 }
 
-impl AccountDirectory for HttpRegistry {
+impl AccountService for HttpRegistry {
     type Error = HttpRegistryError;
 
     fn publish(&mut self, bundle: &SignedDeviceBundle) -> Result<(), Self::Error> {


### PR DESCRIPTION
The changes binds the Account into the MLS leaf credential so a receiver recovers both — verifiably, with no directory round-trip.

- `logos-account`: `credential` module — `encode_credential`  build an account-endorsed credential; `resolve_sender` verifies it against the  leaf device key and returns `MessageSender { account, local_identity }`.
- `conversations`: `get_credential` emits the account-bound credential; `GroupV1`  resolves and attaches the sender; `ConvoOutcome` gains `sender`. GroupV2 surfaces the LocalIdentity (account resolution is a de-mls follow-up).
- `logos-chat`: `Event::MessageReceived` gains `sender`.

Tests: credential codec units + GroupV1 integration assert the verified sender and that distinct identities resolve to distinct accounts. 

Related to https://github.com/logos-messaging/libchat/issues/109