### PR TITLE
Add Identified Trait for convo

### DIFF
--- a/core/conversations/src/conversation.rs
+++ b/core/conversations/src/conversation.rs
@@ -15,7 +15,7 @@ pub type ConversationId = String;
 pub type ConversationIdRef<'a> = &'a str;
 
 /// Behaviour shared by every conversation kind.
-pub(crate) trait Convo<S: ExternalServices> {
+pub(crate) trait Convo<S: ExternalServices>: Identified {
     fn send_content(&mut self, cx: &mut ServiceContext<S>, content: &[u8])
     -> Result<(), ChatError>;
 
@@ -40,6 +40,8 @@ pub(crate) trait GroupConvo<S: ExternalServices>: Convo<S> + std::fmt::Debug + S
         cx: &mut ServiceContext<S>,
         members: &[IdentIdRef],
     ) -> Result<(), ChatError>;
+}
 
-    fn id(&self) -> ConversationIdRef<'_>;
+pub(crate) trait Identified {
+    fn id(&self) -> ConversationIdRef;
 }

--- a/core/conversations/src/conversation.rs
+++ b/core/conversations/src/conversation.rs
@@ -43,5 +43,5 @@ pub(crate) trait GroupConvo<S: ExternalServices>: Convo<S> + std::fmt::Debug + S
 }
 
 pub(crate) trait Identified {
-    fn id(&self) -> ConversationIdRef;
+    fn id(&self) -> ConversationIdRef<'_>;
 }

--- a/core/conversations/src/conversation/group_v1.rs
+++ b/core/conversations/src/conversation/group_v1.rs
@@ -11,12 +11,13 @@ use prost::Message as _;
 use shared_traits::IdentIdRef;
 
 use crate::account_directory::{AccountDirectory, resolve_device_ids};
+use crate::conversation::ConversationIdRef;
 use crate::inbox_v2::MlsProvider;
 use crate::service_context::{ExternalServices, ServiceContext};
 
 use crate::{
     DeliveryService, IdentityProvider,
-    conversation::{ChatError, Convo, GroupConvo},
+    conversation::{ChatError, Convo, GroupConvo, Identified},
     outcomes::{Content, ConvoOutcome},
     service_traits::KeyPackageProvider,
     types::AddressedEncryptedPayload,
@@ -174,10 +175,6 @@ impl GroupV1Convo {
         Ok(keypackages)
     }
 
-    pub fn id(&self) -> &str {
-        &self.convo_id
-    }
-
     fn send_message<S: ExternalServices>(
         &mut self,
         content: &[u8],
@@ -202,6 +199,12 @@ impl GroupV1Convo {
         };
 
         Ok(vec![a])
+    }
+}
+
+impl Identified for GroupV1Convo {
+    fn id(&self) -> ConversationIdRef<'_> {
+        &self.convo_id
     }
 }
 
@@ -343,9 +346,5 @@ impl<S: ExternalServices> GroupConvo<S> for GroupV1Convo {
         cx.ds
             .publish(env)
             .map_err(|e| ChatError::Generic(format!("Publish: {e}")))
-    }
-
-    fn id(&self) -> super::ConversationIdRef<'_> {
-        &self.convo_id
     }
 }

--- a/core/conversations/src/conversation/group_v2.rs
+++ b/core/conversations/src/conversation/group_v2.rs
@@ -31,7 +31,7 @@ use crate::IdentityProvider;
 use crate::conversation::{ConversationIdRef, ExternalServices, ServiceContext};
 use crate::{
     ConvoOutcome, DeliveryService, RegistrationService,
-    conversation::{ChatError, Convo, GroupConvo},
+    conversation::{ChatError, Convo, GroupConvo, Identified},
 };
 
 /// Namespace used for de-mls (GroupV2) keypackages, so they don't collide
@@ -272,6 +272,12 @@ impl GroupV2Convo {
     }
 }
 
+impl Identified for GroupV2Convo {
+    fn id(&self) -> ConversationIdRef<'_> {
+        &self.convo_id
+    }
+}
+
 impl<S> Convo<S> for GroupV2Convo
 where
     S: ExternalServices,
@@ -347,9 +353,6 @@ impl<S> GroupConvo<S> for GroupV2Convo
 where
     S: ExternalServices,
 {
-    fn id(&self) -> ConversationIdRef<'_> {
-        &self.convo_id
-    }
     #[instrument(name = "groupv2.add_member", skip_all, fields(user_id = %service_ctx.mls_identity.display_name()))]
     fn add_member(
         &mut self,

--- a/core/conversations/src/conversation/privatev1.rs
+++ b/core/conversations/src/conversation/privatev1.rs
@@ -14,7 +14,7 @@ use storage::{ConversationKind, ConversationMeta, ConversationStore};
 
 use crate::{
     DeliveryService,
-    conversation::{ChatError, ConversationId, Convo},
+    conversation::{ChatError, ConversationId, ConversationIdRef, Convo, Identified},
     errors::EncryptionError,
     inbox::PRIVATE_V1_INBOX_ADDRESS,
     outcomes::{Content, ConvoOutcome},
@@ -200,10 +200,6 @@ impl PrivateV1Convo {
         }
     }
 
-    pub fn id(&self) -> &str {
-        &self.local_convo_id
-    }
-
     pub fn encrypt_content<S: RatchetStore>(
         &mut self,
         content: &[u8],
@@ -232,6 +228,12 @@ impl PrivateV1Convo {
 
     pub fn convo_type(&self) -> ConversationKind {
         ConversationKind::PrivateV1
+    }
+}
+
+impl Identified for PrivateV1Convo {
+    fn id(&self) -> ConversationIdRef<'_> {
+        &self.local_convo_id
     }
 }
 

--- a/core/conversations/src/core.rs
+++ b/core/conversations/src/core.rs
@@ -1,5 +1,7 @@
 use crate::causal_history::{CausalHistoryStore, MissingMessage};
-use crate::conversation::{ConversationIdRef, GroupV1Convo, GroupV2Convo, PrivateV1Convo};
+use crate::conversation::{
+    ConversationIdRef, GroupV1Convo, GroupV2Convo, Identified, PrivateV1Convo,
+};
 use crate::service_context::{ExternalServices, ServiceContext};
 use crate::{DeliveryService, IdentityProvider, RegistrationService, WakeupService};
 use crate::{
@@ -470,8 +472,8 @@ enum ConvoTypeOwned<S: ExternalServices> {
     Group(Box<dyn GroupConvo<S>>),
 }
 
-impl<'a, S: ExternalServices> ConvoTypeOwned<S> {
-    pub fn id(&'a self) -> ConversationIdRef<'a> {
+impl<S: ExternalServices> Identified for ConvoTypeOwned<S> {
+    fn id(&self) -> ConversationIdRef<'_> {
         match self {
             ConvoTypeOwned::Group(group_convo) => group_convo.id(),
         }

--- a/core/conversations/src/inbox_v2.rs
+++ b/core/conversations/src/inbox_v2.rs
@@ -21,6 +21,7 @@ use crate::RegistrationService;
 use crate::conversation::GroupConvo;
 use crate::conversation::GroupV1Convo;
 use crate::conversation::GroupV2Convo;
+use crate::conversation::Identified as _;
 use crate::service_context::{ExternalServices, ServiceContext};
 use crate::utils::{blake2b_hex, hash_size};
 use crate::{


### PR DESCRIPTION
## Problem 

At some point the Id trait was removed Convo trait, which meant that each ConversationType needed to implement its own function. This meant that calls to id() could not be dynamically dispatched. This is required for future PR updates to allow type erasure. 

## Solution 

Add Identified trait to conversations. The trait is then required by `Convo` trait to ensure that all conversations have the Id method.


## Notes
- The previous trait was named `Id` however conflicted with other objects. `Identified` was chosen to clearly identify its a trait.
