### PR TITLE
feat: update nixpkgs locked version to avoid override nixpkgs in ci.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,15 +64,7 @@ jobs:
           primary-key: nix-${{ runner.os }}-fixtest-${{ hashFiles('flake.nix', 'flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
       - name: Build logos-delivery
-        # Build through a patched nixpkgs (kaichaosun/nixpkgs fix-gitfetch),
-        # whose nix-prefetch-git disables git background auto-maintenance so the
-        # nim-zlib submodule fetch no longer races `.git` removal. The override
-        # flows into logos-delivery via its `nixpkgs.follows`. The bumped cache
-        # key (`-fixtest-`) forces a cold store, so this genuinely re-fetches
-        # nim-zlib instead of reusing a cached output. No retry on purpose: a
-        # single build must now succeed deterministically. Re-run the job a few
-        # times for more samples.
-        run: nix build .#logos-delivery --override-input nixpkgs github:kaichaosun/nixpkgs/fix-gitfetch --print-build-logs
+        run: nix build .#logos-delivery --print-build-logs
       # Build and run chat-cli through the dev shell so it links against the
       # same Nix glibc as the prebuilt liblogosdelivery.so. A plain `cargo
       # build` uses the runner's system glibc, which is older than Nix's and

--- a/flake.lock
+++ b/flake.lock
@@ -24,11 +24,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779955849,
-        "narHash": "sha256-31mhzm2HpzRr/rupWAFfWBmt9SUjzwr5+giv5Nmb/rA=",
+        "lastModified": 1782231800,
+        "narHash": "sha256-AyPvq+cx3JFicSd687dhhIfUMryk9PUFmHnofBjalMg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a2c6938835fca96e4a10c8561d461efd2f91d04f",
+        "rev": "6f5e2d2ea55618c5197ce40e346f205c35d2213e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Update nixpkgs pinned in flake.lock and remove override personal branch.