### PR TITLE
feat: re-export ChatStorage and make storage_config fallible

### DIFF
--- a/bin/chat-cli/src/main.rs
+++ b/bin/chat-cli/src/main.rs
@@ -119,6 +119,7 @@ fn run<T: Transport>(transport: T, cli: &Cli) -> Result<()> {
             let (client, events) = ChatClientBuilder::new()
                 .transport(transport)
                 .storage_config(storage)
+                .map_err(|e| anyhow::anyhow!("{e:?}"))?
                 .registration(registry)
                 .build()
                 .map_err(|e| anyhow::anyhow!("{e:?}"))
@@ -129,6 +130,7 @@ fn run<T: Transport>(transport: T, cli: &Cli) -> Result<()> {
             let (client, events) = ChatClientBuilder::new()
                 .transport(transport)
                 .storage_config(storage)
+                .map_err(|e| anyhow::anyhow!("{e:?}"))?
                 .build()
                 .map_err(|e| anyhow::anyhow!("{e:?}"))
                 .context("failed to open chat client")?;
@@ -197,6 +199,7 @@ fn run_logos_delivery(cli: Cli) -> Result<()> {
                         path: db_str,
                         key: "chat-cli".to_string(),
                     })
+                    .map_err(|e| anyhow::anyhow!("{e:?}"))?
                     .transport(delivery)
                     .build()
                     .map_err(|e| anyhow::anyhow!("{e:?}"))

--- a/crates/client/src/builder.rs
+++ b/crates/client/src/builder.rs
@@ -74,17 +74,18 @@ impl<I, T, R, S> ChatClientBuilder<I, T, R, S> {
         }
     }
 
-    pub fn storage_config(self, config: StorageConfig) -> ChatClientBuilder<I, T, R, ChatStorage> {
-        let storage = ChatStorage::new(config)
-            .map_err(ChatError::from)
-            .expect("Storage config file should be valid");
+    pub fn storage_config(
+        self,
+        config: StorageConfig,
+    ) -> Result<ChatClientBuilder<I, T, R, ChatStorage>, ChatError> {
+        let storage = ChatStorage::new(config).map_err(ChatError::from)?;
 
-        ChatClientBuilder {
+        Ok(ChatClientBuilder {
             ident: self.ident,
             transport: self.transport,
             registration: self.registration,
             storage,
-        }
+        })
     }
 }
 

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -14,7 +14,7 @@ pub use event::{Event, MessageSender};
 
 // Re-export types callers need to interact with ChatClient.
 pub use libchat::{
-    AddressedEnvelope, ChatStore, ConversationClass, ConversationId, DeliveryService,
+    AddressedEnvelope, ChatStorage, ChatStore, ConversationClass, ConversationId, DeliveryService,
     IdentityProvider, RegistrationService, StorageConfig,
 };
 


### PR DESCRIPTION
Two small ergonomic changes to the `logos-chat` client crate, needed by callers
(logos-chat-module) that build an encrypted store and want to talk only to
`logos-chat` without depending on `libchat` directly.

- Re-export `ChatStorage` from `logos-chat` so callers can name the store type
  without a direct `libchat` dependency.
- `ChatClientBuilder::storage_config` now returns `Result<_, ChatError>` instead
  of `.expect()`, so an unopenable database surfaces as an error rather than
  aborting the process under `panic = "abort"`. Updates the chat-cli callers.

(Re-scoped from the earlier PrivateV1 message-delivery change, which is dropped:
logos-chat-module is moving to DirectV1, where senders are MLS-bound and the
PrivateV1 drop does not arise.)
