### PR TITLE
Update demls for external group configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1816,7 +1816,7 @@ dependencies = [
 [[package]]
 name = "de-mls"
 version = "4.0.0"
-source = "git+https://github.com/vacp2p/de-mls?branch=main#3056898d07519bc6d8fbf58ce5cb4e004e4cc932"
+source = "git+https://github.com/vacp2p/de-mls?branch=main#09533ce21021beea9903993a8f41f570e5b46b13"
 dependencies = [
  "hashgraph-like-consensus",
  "indexmap 2.14.0",

--- a/core/conversations/src/conversation/group_v2.rs
+++ b/core/conversations/src/conversation/group_v2.rs
@@ -16,13 +16,12 @@ use de_mls::{
     defaults::{DefaultConsensusPlugin, DefaultPeerScoring, InMemoryPeerScoreStorage},
 };
 use hashgraph_like_consensus::signing::EthereumConsensusSigner;
+use openmls::group::MlsGroupCreateConfig;
 use prost::Message;
 use shared_traits::{IdentId, IdentIdRef};
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{info, instrument, warn};
-
-use crate::inbox_v2::CIPHER_SUITE;
 
 use crate::IdentityProvider;
 use crate::conversation::{ConversationIdRef, ExternalServices, ServiceContext};
@@ -92,6 +91,12 @@ fn rand_string(n: usize) -> String {
     hex::encode(bytes)
 }
 
+fn group_config() -> MlsGroupCreateConfig {
+    MlsGroupCreateConfig::builder()
+        .use_ratchet_tree_extension(true)
+        .build()
+}
+
 impl GroupV2Convo {
     pub fn new<S: ExternalServices>(
         service_ctx: &mut ServiceContext<S>,
@@ -102,7 +107,7 @@ impl GroupV2Convo {
             &member_id(service_ctx),
             &service_ctx.mls_provider,
             service_ctx.mls_identity.get_credential(),
-            CIPHER_SUITE,
+            &group_config(),
             &service_ctx.mls_identity,
             &make_consensus(),
             make_scoring(),


### PR DESCRIPTION
This PR updates the demls dependency to use: https://github.com/vacp2p/de-mls/pull/126