### PR TITLE
bump de-mls version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1816,7 +1816,7 @@ dependencies = [
 [[package]]
 name = "de-mls"
 version = "4.0.0"
-source = "git+https://github.com/vacp2p/de-mls?branch=main#09533ce21021beea9903993a8f41f570e5b46b13"
+source = "git+https://github.com/vacp2p/de-mls?branch=main#2b3eed17723d4fb12037ef8cfb1f5e8c115b09a1"
 dependencies = [
  "hashgraph-like-consensus",
  "indexmap 2.14.0",


### PR DESCRIPTION
New main branch have a bug fix - the one when we try to apply another commit and discard our own for this, but we shouldn't do it. We should use openmls part to handle such a situation, so I fixed it. 

Also, in this update we set the commit with mls config setup. 