### PR TITLE
feat: GroupV2 through the threaded client, group roster, registry retry

### DIFF
--- a/core/conversations/src/conversation/group_v2.rs
+++ b/core/conversations/src/conversation/group_v2.rs
@@ -11,8 +11,7 @@ use de_mls::protos::de_mls::messages::v1::{
     AppMessage as AppMessageProto, MemberWelcome, app_message,
 };
 use de_mls::{
-    Conversation, ConversationConfig, ConversationEvent, PeerScoringService, ScoringConfig,
-    default_score_deltas,
+    Conversation, ConversationEvent, PeerScoringService, ScoringConfig, default_score_deltas,
     defaults::{DefaultConsensusPlugin, DefaultPeerScoring, InMemoryPeerScoreStorage},
 };
 use hashgraph_like_consensus::signing::EthereumConsensusSigner;
@@ -22,7 +21,6 @@ use openmls::prelude::{KeyPackageIn, OpenMlsProvider as _, ProtocolVersion};
 use prost::Message;
 use shared_traits::{IdentId, IdentIdRef};
 use std::sync::Arc;
-use std::time::Duration;
 use tracing::{info, instrument, warn};
 
 use crate::IdentityProvider;
@@ -56,21 +54,6 @@ fn make_scoring() -> DefaultPeerScoring {
 /// random Ethereum consensus signer.
 fn make_consensus() -> DefaultConsensusPlugin {
     DefaultConsensusPlugin::new(EthereumConsensusSigner::new(PrivateKeySigner::random()))
-}
-
-/// TEST-ONLY millisecond timers. de-mls deadlines are real wall-clock, so the
-/// default 60s timers never fire under fast virtual time. Production needs a
-/// real config injected from the caller, not these hardcoded values.
-fn demls_config() -> ConversationConfig {
-    ConversationConfig {
-        commit_inactivity_duration: Duration::from_millis(50),
-        freeze_duration: Duration::from_millis(20),
-        voting_delay: Duration::from_millis(30),
-        election_voting_delay: Duration::from_millis(30),
-        consensus_timeout: Duration::from_millis(150),
-        proposal_expiration: Duration::from_millis(2000),
-        ..ConversationConfig::default()
-    }
 }
 
 pub struct GroupV2Convo {
@@ -116,7 +99,7 @@ impl GroupV2Convo {
             &make_consensus(),
             make_scoring(),
             rand_app_id(),
-            demls_config(),
+            service_ctx.group_v2_config.clone(),
         )?;
         let convo = GroupV2Convo {
             convo_id,
@@ -147,7 +130,7 @@ impl GroupV2Convo {
             &make_consensus(),
             make_scoring(),
             rand_app_id(),
-            demls_config(),
+            service_ctx.group_v2_config.clone(),
         )?
         else {
             return Err(ChatError::generic("welcome not addressed to this member"));
@@ -277,13 +260,14 @@ where
         service_ctx: &mut ServiceContext<S>,
         members: &[IdentIdRef],
     ) -> Result<(), ChatError> {
-        // Record who WE invited before touching the conversation: after_op
-        // forwards a welcome only to joiners in pending_invites. Members are
-        // signer ids; the de-mls member id must match the id of the
-        // IdentityProvider that generated the key package (its MLS leaf
-        // credential content — de-mls matches members by credential), so it is
-        // read from the fetched key package rather than assumed equal to the
-        // signer id.
+        // Fetch and validate every key package before proposing any add, so a
+        // member with no key package fails the call before it opens proposals
+        // for the others. Members are signer ids; the de-mls member id must
+        // match the id of the IdentityProvider that generated the key package
+        // (its MLS leaf credential content — de-mls matches members by
+        // credential), so it is read from the fetched key package rather than
+        // assumed equal to the signer id.
+        let mut invites = Vec::with_capacity(members.len());
         for member in members {
             let kp_bytes = service_ctx
                 .registry
@@ -298,17 +282,38 @@ where
                 .credential()
                 .serialized_content()
                 .to_vec();
-            self.pending_invites
-                .push((member_id.clone(), member.to_string()));
-            self.conversation.add_member(
+            invites.push((member_id, member.to_string(), kp_bytes));
+        }
+
+        // Record who WE invited before touching the conversation: after_op
+        // forwards a welcome only to joiners in pending_invites. Skip a member
+        // de-mls would silently not propose (self, or already in the group) —
+        // recording it would strand a pending invite that later matches a
+        // re-join and fires a duplicate welcome.
+        let mut result = Ok(());
+        for (member_id, signer_id, kp_bytes) in invites {
+            if member_id == self.conversation.member_id_bytes()
+                || self.conversation.members()?.contains(&member_id)
+            {
+                continue;
+            }
+            self.pending_invites.push((member_id.clone(), signer_id));
+            if let Err(e) = self.conversation.add_member(
                 &service_ctx.mls_provider,
                 &service_ctx.mls_identity,
                 &member_id,
                 &kp_bytes,
-            )?;
+            ) {
+                self.pending_invites.pop();
+                result = Err(e.into());
+                break;
+            }
         }
-        self.after_op(service_ctx)?;
-        Ok(())
+        // Flush even on a mid-loop failure: proposals already opened must be
+        // published and the wakeup re-armed, or they sit dormant until an
+        // unrelated frame drives the conversation.
+        let flushed = self.after_op(service_ctx).map(drop);
+        result.and(flushed)
     }
 
     // fn conversation_state(&self) -> Result<ConversationState, ChatError> {

--- a/core/conversations/src/core.rs
+++ b/core/conversations/src/core.rs
@@ -3,7 +3,7 @@ use crate::conversation::{
     ConversationIdRef, DirectV1Convo, GroupV1Convo, GroupV2Convo, Identified, PrivateV1Convo,
 };
 use crate::service_context::{ExternalServices, ServiceContext};
-use crate::{DeliveryService, IdentityProvider, RegistrationService, WakeupService};
+use crate::{DeliveryService, GroupV2Config, IdentityProvider, RegistrationService, WakeupService};
 use crate::{
     conversation::{Convo, GroupConvo},
     errors::ChatError,
@@ -140,6 +140,7 @@ where
                 causal,
                 identity,
                 wakeup_service,
+                group_v2_config: GroupV2Config::default(),
             },
             inbox,
             pq_inbox,
@@ -172,6 +173,12 @@ impl<'a, S: ExternalServices + 'static> Core<S> {
     /// the most recent N submissions; older entries are pruned).
     pub fn register_keypackage(&mut self) -> Result<(), ChatError> {
         self.pq_inbox.register(&mut self.services)
+    }
+
+    /// Timing/policy for GroupV2 conversations created or joined after this
+    /// call. Existing conversations keep the config they were built with.
+    pub fn set_group_v2_config(&mut self, config: GroupV2Config) {
+        self.services.group_v2_config = config;
     }
 
     pub fn installation_name(&self) -> &str {

--- a/core/conversations/src/lib.rs
+++ b/core/conversations/src/lib.rs
@@ -16,6 +16,13 @@ pub use causal_history::{Frontier, MissingMessage};
 pub use chat_sqlite::ChatStorage;
 pub use chat_sqlite::StorageConfig;
 pub use core::{ConversationId, Core, Introduction};
+/// Timing/policy for GroupV2 conversations (de-mls's per-conversation config).
+/// Defaults to the de-mls library defaults; inject via
+/// [`Core::set_group_v2_config`]. The creator's phase durations (commit
+/// inactivity, freeze, recovery, voting inactivity, proposal expiration,
+/// consensus timeout) travel to joiners with the welcome and overwrite
+/// theirs; vote delays and the policy fields stay local to each member.
+pub use de_mls::ConversationConfig as GroupV2Config;
 pub use errors::ChatError;
 pub use outcomes::{
     Content, ConversationClass, ConvoOutcome, InboxOutcome, NewConversation, PayloadOutcome,

--- a/core/conversations/src/service_context.rs
+++ b/core/conversations/src/service_context.rs
@@ -44,6 +44,11 @@ pub(crate) struct ServiceContext<S: ExternalServices> {
     pub(crate) causal: CausalHistoryStore,
     pub(crate) identity: Identity,
     pub(crate) wakeup_service: S::WS,
+    /// Timing/policy applied to GroupV2 conversations created or joined by
+    /// this core. Read at conversation construction; a joiner's phase
+    /// durations are then overwritten by the creator's, carried with the
+    /// welcome (vote delays and policy fields stay local).
+    pub(crate) group_v2_config: de_mls::ConversationConfig,
 }
 
 #[cfg(test)]
@@ -110,6 +115,7 @@ mod test_support {
                 causal: CausalHistoryStore::new(),
                 identity: Identity::new(name),
                 wakeup_service: NoopWakeups {},
+                group_v2_config: de_mls::ConversationConfig::default(),
             })
         }
     }

--- a/core/integration_tests_core/src/test_client.rs
+++ b/core/integration_tests_core/src/test_client.rs
@@ -1,5 +1,5 @@
 use crate::test_ident::TestIdent;
-use libchat::{ConversationId, Core, IdentityProvider, PayloadOutcome};
+use libchat::{ConversationId, Core, GroupV2Config, IdentityProvider, PayloadOutcome};
 use shared_traits::IdentId;
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -20,6 +20,21 @@ const SARO: usize = 0;
 const RAYA: usize = 1;
 const PAX: usize = 2;
 const MIRA: usize = 3;
+
+/// Millisecond GroupV2 timers for the harness. de-mls deadlines are real
+/// wall-clock, so the library defaults (60s commit inactivity) would stall
+/// `process_until`, which settles in 50ms steps.
+fn fast_group_v2_config() -> GroupV2Config {
+    GroupV2Config {
+        commit_inactivity_duration: Duration::from_millis(50),
+        freeze_duration: Duration::from_millis(20),
+        voting_delay: Duration::from_millis(30),
+        election_voting_delay: Duration::from_millis(30),
+        consensus_timeout: Duration::from_millis(150),
+        proposal_expiration: Duration::from_millis(2000),
+        ..GroupV2Config::default()
+    }
+}
 
 // type ClientType = CoreClient<TestIdent, LocalBroadcaster, EphemeralRegistry, WP, MemStore>;
 type ClientType = Core<(TestIdent, LocalBroadcaster, EphemeralRegistry, WP, MemStore)>;
@@ -148,9 +163,10 @@ impl<const N: usize> TestHarness<N> {
             let ident = TestIdent::new(Self::names(i));
 
             addresses.insert(i, ident.id().clone());
-            let core_client =
+            let mut core_client =
                 ClientType::new_with_name(ident, ds.clone(), rs.clone(), wp, MemStore::new())
                     .unwrap();
+            core_client.set_group_v2_config(fast_group_v2_config());
 
             let client = TestClient::init(core_client);
 

--- a/crates/client/src/builder.rs
+++ b/crates/client/src/builder.rs
@@ -1,6 +1,6 @@
 use components::EphemeralRegistry;
 use crossbeam_channel::Receiver;
-use libchat::{ChatError, ChatStorage, RegistrationService, StorageConfig};
+use libchat::{ChatError, ChatStorage, GroupV2Config, RegistrationService, StorageConfig};
 use logos_account::AccountDirectory;
 use storage::ChatStore;
 
@@ -20,6 +20,7 @@ pub struct ChatClientBuilder<I = Unset, T = Unset, R = Unset, S = Unset> {
     transport: T,
     registration: R,
     storage: S,
+    group_v2: Option<GroupV2Config>,
 }
 
 impl ChatClientBuilder {
@@ -35,6 +36,7 @@ impl ChatClientBuilder {
             transport: Unset,
             registration: Unset,
             storage: Unset,
+            group_v2: None,
         }
     }
 }
@@ -47,6 +49,7 @@ impl<I, T, R, S> ChatClientBuilder<I, T, R, S> {
             transport: self.transport,
             registration: self.registration,
             storage: self.storage,
+            group_v2: self.group_v2,
         }
     }
 
@@ -57,6 +60,7 @@ impl<I, T, R, S> ChatClientBuilder<I, T, R, S> {
             transport,
             registration: self.registration,
             storage: self.storage,
+            group_v2: self.group_v2,
         }
     }
 
@@ -67,6 +71,7 @@ impl<I, T, R, S> ChatClientBuilder<I, T, R, S> {
             transport: self.transport,
             registration,
             storage: self.storage,
+            group_v2: self.group_v2,
         }
     }
 
@@ -77,6 +82,7 @@ impl<I, T, R, S> ChatClientBuilder<I, T, R, S> {
             transport: self.transport,
             registration: self.registration,
             storage,
+            group_v2: self.group_v2,
         }
     }
 
@@ -91,7 +97,17 @@ impl<I, T, R, S> ChatClientBuilder<I, T, R, S> {
             transport: self.transport,
             registration: self.registration,
             storage,
+            group_v2: self.group_v2,
         }
+    }
+
+    /// Timing/policy for GroupV2 conversations this client creates or joins.
+    /// Defaults to the de-mls library defaults; the creator's phase durations
+    /// travel to joiners with the welcome and overwrite theirs (vote delays
+    /// and policy fields stay local).
+    pub fn group_v2_config(mut self, config: GroupV2Config) -> Self {
+        self.group_v2 = Some(config);
+        self
     }
 }
 
@@ -111,6 +127,7 @@ where
             self.transport,
             self.registration,
             self.storage,
+            self.group_v2,
         )
     }
 }
@@ -124,6 +141,7 @@ impl<T: Transport + Send + 'static> ChatClientBuilder<Unset, T, Unset, Unset> {
             self.transport,
             EphemeralRegistry::new(),
             ChatStorage::in_memory(),
+            self.group_v2,
         )
     }
 }
@@ -140,6 +158,7 @@ where
             self.transport,
             EphemeralRegistry::new(),
             ChatStorage::in_memory(),
+            self.group_v2,
         )
     }
 }
@@ -157,6 +176,7 @@ where
             self.transport,
             self.registration,
             ChatStorage::in_memory(),
+            self.group_v2,
         )
     }
 }
@@ -174,6 +194,7 @@ where
             self.transport,
             EphemeralRegistry::new(),
             self.storage,
+            self.group_v2,
         )
     }
 }
@@ -191,6 +212,7 @@ where
             self.transport,
             self.registration,
             ChatStorage::in_memory(),
+            self.group_v2,
         )
     }
 }
@@ -209,6 +231,7 @@ where
             self.transport,
             self.registration,
             self.storage,
+            self.group_v2,
         )
     }
 }
@@ -226,6 +249,7 @@ where
             self.transport,
             EphemeralRegistry::new(),
             self.storage,
+            self.group_v2,
         )
     }
 }

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -5,8 +5,8 @@ use components::{ThreadedWakeupService, WakeupEvent};
 use crossbeam_channel::{Receiver, Sender, select};
 use crypto::Ed25519VerifyingKey;
 use libchat::{
-    ConversationId, ConvoOutcome, Core, DeliveryService, IdentId, IdentIdRef, InboxOutcome,
-    Introduction, PayloadOutcome, RegistrationService,
+    ConversationId, ConvoOutcome, Core, DeliveryService, GroupV2Config, IdentId, IdentIdRef,
+    InboxOutcome, Introduction, PayloadOutcome, RegistrationService,
 };
 use logos_account::{AccountDirectory, resolve_device_ids};
 use parking_lot::Mutex;
@@ -73,6 +73,7 @@ where
         mut transport: T,
         reg: R,
         storage: S,
+        group_v2: Option<GroupV2Config>,
     ) -> Result<(Self, Receiver<Event>), ClientError> {
         let inbound = transport.inbound();
 
@@ -80,7 +81,10 @@ where
         let wakeup_service = ThreadedWakeupService::new(wakeup_tx);
         let directory = reg.clone();
         let ident = DelegateIdentity::new(ident, &account);
-        let core = Core::new_with_name(ident, transport, reg, wakeup_service, storage)?;
+        let mut core = Core::new_with_name(ident, transport, reg, wakeup_service, storage)?;
+        if let Some(config) = group_v2 {
+            core.set_group_v2_config(config);
+        }
         Ok(Self::spawn(core, directory, account, inbound, wakeup_rx))
     }
 
@@ -151,6 +155,40 @@ where
             .map_err(Into::into)
     }
 
+    /// Create a GroupV2 conversation with the given accounts' devices. Each
+    /// account resolves to the signer ids its directory bundle endorses; the
+    /// group invite goes to every one of them. An empty slice creates a group
+    /// with only this client, to grow via [`Self::add_group_members`].
+    pub fn create_group_conversation(
+        &mut self,
+        accounts: &[AccountAddressRef],
+    ) -> Result<ConversationId, ClientError> {
+        let signers = self.signers_from_accounts(accounts)?;
+        let signer_refs: Vec<IdentIdRef> = signers.iter().collect();
+
+        self.core
+            .lock()
+            .create_group_convo(&signer_refs)
+            .map_err(Into::into)
+    }
+
+    /// Add accounts' devices to an existing group conversation. Membership
+    /// changes are agreed and committed by the group asynchronously; the
+    /// joiners' welcomes go out once the add commits.
+    pub fn add_group_members(
+        &mut self,
+        convo_id: &str,
+        accounts: &[AccountAddressRef],
+    ) -> Result<(), ClientError> {
+        let signers = self.signers_from_accounts(accounts)?;
+        let signer_refs: Vec<IdentIdRef> = signers.iter().collect();
+
+        self.core
+            .lock()
+            .group_add_member(convo_id, &signer_refs)
+            .map_err(Into::into)
+    }
+
     /// Parse intro bundle bytes and initiate a private conversation. Outbound
     /// envelopes are published by the core. Returns this side's conversation ID.
     ///
@@ -192,6 +230,19 @@ where
         let device_ids = resolve_device_ids(&self.directory, &account)
             .map_err(|e| ClientError::AccountResolution(e.to_string()))?;
         Ok(device_ids.into_iter().map(IdentId::new).collect())
+    }
+
+    /// Resolve each account to its signer ids and flatten them, failing on the
+    /// first unresolvable account.
+    fn signers_from_accounts(
+        &self,
+        accounts: &[AccountAddressRef],
+    ) -> Result<Vec<LocalSignerId>, ClientError> {
+        let mut signers = Vec::new();
+        for account in accounts {
+            signers.extend(self.signers_from_account(account)?);
+        }
+        Ok(signers)
     }
 }
 

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -21,7 +21,7 @@ pub use logos::LogosChatClient;
 // Re-export types callers need to interact with ChatClient.
 pub use libchat::{
     AddressedEnvelope, ChatStore, ConversationClass, ConversationId, DeliveryService,
-    IdentityProvider, RegistrationService, StorageConfig,
+    GroupV2Config, IdentityProvider, RegistrationService, StorageConfig,
 };
 // The directory trait bounds ChatClient's registry parameter, so callers
 // writing code generic over ChatClient need it too.

--- a/crates/client/tests/group_v2.rs
+++ b/crates/client/tests/group_v2.rs
@@ -1,0 +1,231 @@
+//! GroupV2 through the threaded client: three accounts on the in-process
+//! transport, driven purely over the public `ChatClient` API and its event
+//! channel. Group commits and welcomes are minted asynchronously by de-mls
+//! (wakeup-driven), so assertions wait for events rather than expecting a
+//! fixed sequence.
+
+use std::time::Duration;
+
+use components::EphemeralRegistry;
+use crossbeam_channel::Receiver;
+use libchat::ChatStorage;
+use logos_account::TestLogosAccount;
+use logos_chat::{
+    ChatClient, ChatClientBuilder, ConversationClass, DelegateSigner, Event, GroupV2Config,
+    InProcessDelivery, MessageBus,
+};
+
+/// Millisecond GroupV2 timers so the de-mls commit/consensus dance completes
+/// in test time; the library defaults wait 60s before committing an add.
+fn fast_group_v2_config() -> GroupV2Config {
+    GroupV2Config {
+        commit_inactivity_duration: Duration::from_millis(50),
+        freeze_duration: Duration::from_millis(20),
+        voting_delay: Duration::from_millis(30),
+        election_voting_delay: Duration::from_millis(30),
+        consensus_timeout: Duration::from_millis(150),
+        proposal_expiration: Duration::from_millis(2000),
+        ..GroupV2Config::default()
+    }
+}
+
+type TestClient = ChatClient<InProcessDelivery, EphemeralRegistry, ChatStorage>;
+
+/// A client for a fresh account: mints the account and a delegate, publishes
+/// the endorsing bundle, and builds the client on the shared bus/registry with
+/// the fast GroupV2 timers. Returns the account address peers invite by.
+fn create_test_client(
+    message_bus: MessageBus,
+    mut reg: EphemeralRegistry,
+) -> (TestClient, Receiver<Event>, String) {
+    let account = TestLogosAccount::new();
+    let delegate = DelegateSigner::random();
+    account
+        .add_delegate_signer(&mut reg, delegate.public_key())
+        .unwrap();
+    let (client, events) = ChatClientBuilder::new(account.address())
+        .ident(delegate)
+        .transport(InProcessDelivery::new(message_bus))
+        .registration(reg)
+        .group_v2_config(fast_group_v2_config())
+        .build()
+        .expect("client create");
+    let addr = client.addr().to_string();
+    (client, events, addr)
+}
+
+/// Wait until an event matching `f` arrives, skipping unrelated events (group
+/// protocol traffic can interleave observations); panic after `timeout`.
+fn wait_for_event<F, T>(events: &Receiver<Event>, label: &str, timeout: Duration, mut f: F) -> T
+where
+    F: FnMut(&Event) -> Option<T>,
+{
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        let remaining = deadline
+            .checked_duration_since(std::time::Instant::now())
+            .unwrap_or_else(|| panic!("timed out waiting for {label}"));
+        match events.recv_timeout(remaining) {
+            Ok(event) => {
+                if let Some(out) = f(&event) {
+                    return out;
+                }
+            }
+            Err(_) => panic!("timed out waiting for {label}"),
+        }
+    }
+}
+
+/// Wait for the group conversation to start on a joiner and return its id.
+fn wait_for_group_started(events: &Receiver<Event>, label: &str) -> String {
+    wait_for_event(events, label, Duration::from_secs(10), |e| match e {
+        Event::ConversationStarted { convo_id, class } => {
+            assert_eq!(*class, ConversationClass::Group);
+            Some(convo_id.to_string())
+        }
+        _ => None,
+    })
+}
+
+/// Wait for `content` to arrive and return the sender's verified account.
+fn wait_for_message(events: &Receiver<Event>, content: &[u8]) -> Option<String> {
+    let label = format!("MessageReceived({})", String::from_utf8_lossy(content));
+    wait_for_event(events, &label, Duration::from_secs(10), |e| match e {
+        Event::MessageReceived {
+            content: got,
+            sender,
+            ..
+        } if got == content => Some(sender.account.as_ref().map(|a| a.as_str().to_string())),
+        _ => None,
+    })
+}
+
+/// A three-account group: saro creates it with raya, raya (a non-creator)
+/// adds pax, and a message from each member reaches both others with a
+/// directory-verified sender account.
+#[test]
+fn group_v2_three_members() {
+    let bus = MessageBus::default();
+    let reg = EphemeralRegistry::new();
+
+    let (mut saro, saro_events, saro_addr) = create_test_client(bus.clone(), reg.clone());
+    let (mut raya, raya_events, raya_addr) = create_test_client(bus.clone(), reg.clone());
+    let (mut pax, pax_events, pax_addr) = create_test_client(bus.clone(), reg.clone());
+
+    let convo_id = saro
+        .create_group_conversation(&[&raya_addr])
+        .expect("saro create group");
+
+    // The invite lands once saro's steward commit finalizes (wakeup-driven);
+    // both sides then share the de-mls conversation id.
+    let raya_convo_id = wait_for_group_started(&raya_events, "raya ConversationStarted");
+    assert_eq!(raya_convo_id, convo_id);
+
+    saro.send_message(&convo_id, b"hello raya").unwrap();
+    assert_eq!(
+        wait_for_message(&raya_events, b"hello raya").as_deref(),
+        Some(saro_addr.as_str())
+    );
+
+    raya.send_message(&raya_convo_id, b"hi saro").unwrap();
+    assert_eq!(
+        wait_for_message(&saro_events, b"hi saro").as_deref(),
+        Some(raya_addr.as_str())
+    );
+
+    // A non-creator grows the group: raya proposes pax, the steward commits,
+    // and raya (who holds the pending invite) routes the welcome to pax.
+    raya.add_group_members(&raya_convo_id, &[&pax_addr])
+        .expect("raya add pax");
+    let pax_convo_id = wait_for_group_started(&pax_events, "pax ConversationStarted");
+    assert_eq!(pax_convo_id, convo_id);
+
+    // Everyone is at the post-add epoch: a message from the creator reaches
+    // both peers, and one from the newest member reaches both elders.
+    saro.send_message(&convo_id, b"all three?").unwrap();
+    assert_eq!(
+        wait_for_message(&raya_events, b"all three?").as_deref(),
+        Some(saro_addr.as_str())
+    );
+    assert_eq!(
+        wait_for_message(&pax_events, b"all three?").as_deref(),
+        Some(saro_addr.as_str())
+    );
+
+    pax.send_message(&pax_convo_id, b"pax is in").unwrap();
+    assert_eq!(
+        wait_for_message(&saro_events, b"pax is in").as_deref(),
+        Some(pax_addr.as_str())
+    );
+    assert_eq!(
+        wait_for_message(&raya_events, b"pax is in").as_deref(),
+        Some(pax_addr.as_str())
+    );
+
+    assert_eq!(saro.list_conversations().unwrap().len(), 1);
+    assert_eq!(raya.list_conversations().unwrap().len(), 1);
+    assert_eq!(pax.list_conversations().unwrap().len(), 1);
+}
+
+/// A batch add is validated before any member is proposed: a member whose
+/// account is endorsed in the directory but whose device registered no key
+/// package fails the whole call, the resolvable member in the same batch is
+/// not invited, and the group keeps working.
+#[test]
+fn add_batch_with_missing_key_package_invites_no_one() {
+    let bus = MessageBus::default();
+    let mut reg = EphemeralRegistry::new();
+
+    let (mut saro, _saro_events, _saro_addr) = create_test_client(bus.clone(), reg.clone());
+    let (_raya, raya_events, raya_addr) = create_test_client(bus.clone(), reg.clone());
+    let (_pax, pax_events, pax_addr) = create_test_client(bus.clone(), reg.clone());
+
+    // Ghost: its account endorses a device in the directory, but that device
+    // never registered a key package (no client was built for it).
+    let ghost_account = TestLogosAccount::new();
+    let ghost_delegate = DelegateSigner::random();
+    ghost_account
+        .add_delegate_signer(&mut reg, ghost_delegate.public_key())
+        .unwrap();
+
+    let convo_id = saro
+        .create_group_conversation(&[&raya_addr])
+        .expect("saro create group");
+    wait_for_group_started(&raya_events, "raya ConversationStarted");
+
+    saro.add_group_members(&convo_id, &[&ghost_account.address(), &pax_addr])
+        .expect_err("ghost has no key package");
+
+    // Pax was in the failed batch and must not have been invited.
+    assert!(
+        pax_events.recv_timeout(Duration::from_secs(1)).is_err(),
+        "pax must not join from a failed batch"
+    );
+
+    // The failed add left the group functional.
+    saro.send_message(&convo_id, b"still alive").unwrap();
+    wait_for_message(&raya_events, b"still alive");
+}
+
+/// Group membership is resolved through the account directory, so inviting an
+/// address whose account never published a bundle fails at resolution — on
+/// create and on add alike.
+#[test]
+fn group_invite_of_unpublished_account_is_an_error() {
+    let bus = MessageBus::default();
+    let reg = EphemeralRegistry::new();
+
+    let (mut saro, _saro_events, _saro_addr) = create_test_client(bus.clone(), reg.clone());
+    let unpublished = TestLogosAccount::new();
+
+    let err = saro
+        .create_group_conversation(&[&unpublished.address()])
+        .expect_err("no bundle published for the account");
+    assert!(matches!(err, logos_chat::ClientError::AccountResolution(_)));
+
+    let convo_id = saro.create_group_conversation(&[]).expect("empty group");
+    let err = saro
+        .add_group_members(&convo_id, &[&unpublished.address()])
+        .expect_err("no bundle published for the account");
+    assert!(matches!(err, logos_chat::ClientError::AccountResolution(_)));
+}


### PR DESCRIPTION
## feat: expose GroupV2 through the threaded client

GroupV2 (de-mls) conversations were reachable only from Core, and every
conversation ran the hardcoded millisecond timer profile in group_v2.rs
(20-150 ms freeze/consensus windows), which cannot survive real network
latency. Downstream logos-chat-module needs group conversations through
ChatClient over the deployed devnet stack.

- ChatClient::create_group_conversation(accounts) and
  add_group_members(convo_id, accounts): resolve each account address to
  its endorsed signer ids through the client-held directory, the same
  resolution create_direct_conversation uses, and drive
  Core::create_group_convo / group_add_member.
- GroupV2 timing/policy is injectable: ServiceContext carries a
  de_mls::ConversationConfig (re-exported as GroupV2Config) defaulting
  to the de-mls library defaults; Core::set_group_v2_config and the
  builder's group_v2_config setter override it. The creator's phase
  durations reach joiners inside the welcome's ConversationSync, so the
  group runs the creator's phase timing.
- GroupV2Convo::add_member validates every member's key package before
  proposing any add, skips members de-mls would silently not propose
  (self, already in the group) instead of stranding a pending invite,
  and flushes opened proposals even on a mid-batch failure, so a failed
  batch cannot invite members behind the caller's back.
- The millisecond test profile moves into the test harnesses
  (integration_tests_core's TestHarness, crates/client/tests/group_v2.rs).
- New client-level tests: three accounts on the in-process transport
  create a group, a non-creator adds the third member, and messages fan
  out with directory-verified senders; a batch containing a member with
  no key package fails without inviting anyone.


## fix: class inbound DirectV1 joins as Private, not Group

The joiner of a DirectV1 (pairwise) conversation received it classed as
Group, because dispatch_to_inbox2 hardcoded ConversationClass::Group for
every InboxV2 join. DirectV1 welcomes (InviteType::GroupV1) and GroupV2
welcomes (InviteType::GroupV2) both arrive over InboxV2, so a plain 1:1
invite surfaced to the display layer as a group. ConversationClass is
documented as stable across protocol versions of the same conversation
shape, and DirectV1 is the pairwise shape, so its joiner must see Private.

- InboxV2::handle_frame returns the class alongside the convo:
  InviteType::GroupV1 (the DirectV1 welcome carrier) yields Private,
  InviteType::GroupV2 yields Group.
- dispatch_to_inbox2 propagates that class instead of hardcoding Group.
- direct_v1_by_account_address asserts the joiner sees Private.


## feat: expose a group's roster, deduped to one entry per account

The display layer needs a group's membership, but nothing exposed it:
de-mls holds the authoritative roster (MLS group state) with no public
accessor, and members added by other members stay invisible until they
send a message. Rebuilding the roster from observed messages would fork
state the crypto layer owns and be wrong exactly when a group grows.

- GroupConvo::members() returns each member's hex-encoded MLS
  leaf-credential content, self included. GroupV2Convo delegates to
  de-mls and guarantees self-inclusion; GroupV1Convo reads its openmls
  leaves.
- Core::group_members(convo_id) mirrors group_add_member's dispatch: a
  cached group yields its members, a direct conversation is an
  UnsupportedFunction, otherwise the group is loaded.
- ChatClient::group_members returns Vec<GroupMember>, resolving each
  member's account claim through the directory. A member whose account
  claim is unconfirmable is listed by device with account None rather
  than dropped: it is cryptographically in the group, only the account
  claim is unproven. The credential parsing decode_sender did is
  factored into parse_credential and shared by both, leaving
  decode_sender's stricter drop semantics for message senders unchanged.
- Because resolve_device_ids fans an account out to every endorsed
  device, an account whose devices all join surfaced once per device;
  group_members dedups by account, keeping the first-seen device as the
  account's representative. Members with no confirmed account stay
  individual, keyed by their unique device key.
- Unit tests cover the tolerant-vs-drop split and the per-account dedup;
  the three-member group integration test asserts the roster converges
  after create and after each add, and a solo group lists only its
  creator.


## feat: retry the registry on transient 5xx with backoff and jitter

The keypackage/account registry is reliable request-by-request but sheds concurrent bursts with a 5xx, so several instances registering at once each hard-failed on init. HttpRegistry's four calls now retry network errors and 5xx/429 with exponential backoff and full jitter (the jitter decorrelates concurrent publishers so their retries don't re-collide); 4xx and success return immediately. Bounded to a few seconds, within the module's init IPC budget.


