### PR TITLE
fix: lock xeddsa to 1.0.2 to avoid breaking change

### DIFF
--- a/core/crypto/Cargo.toml
+++ b/core/crypto/Cargo.toml
@@ -12,5 +12,5 @@ rand_core = { version = "0.6", features = ["getrandom"] }
 sha2 = "0.10"
 thiserror = "2"
 x25519-dalek = { version = "2.0.1", features = ["static_secrets"] }
-xeddsa = "1.0.2"
+xeddsa = "=1.0.2"
 zeroize = { version = "1.8.2", features = ["derive"] }


### PR DESCRIPTION
## Problem

Importing `logos-chat` into a project results in compile errors.
Xeddsa introduced a breaking change in 1.1.0, and this library does not constrain the version of the library.

## Solution

Fix the dependency to a specific version, such that cargo installs the correct dependency

## Notes

- Version 1.1.0 does not contain any critical changes requiring an immediate update 