### PR TITLE
feat(group_v2): event-driven liveness + found-with-members

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "de-mls"
 version = "4.0.0"
-source = "git+https://github.com/vacp2p/de-mls?branch=develop#f7c1271efb617ba7b62e8b6fc16b4fba1889ffce"
+source = "git+https://github.com/vacp2p/de-mls?branch=develop#04bcd5d06f53da1a91f166f8002a89322b1adedf"
 dependencies = [
  "hashgraph-like-consensus",
  "indexmap 2.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "de-mls"
 version = "4.0.0"
-source = "git+https://github.com/vacp2p/de-mls?rev=2c7a8669c1492c749c02efd2c5ac45e93e4926a3#2c7a8669c1492c749c02efd2c5ac45e93e4926a3"
+source = "git+https://github.com/vacp2p/de-mls?branch=develop#f7c1271efb617ba7b62e8b6fc16b4fba1889ffce"
 dependencies = [
  "hashgraph-like-consensus",
  "indexmap 2.14.0",

--- a/core/conversations/Cargo.toml
+++ b/core/conversations/Cargo.toml
@@ -18,7 +18,7 @@ storage = { workspace = true }
 alloy = "2.0"
 base64 = "0.22"
 chat-proto = { workspace = true }
-de-mls = { git = "https://github.com/vacp2p/de-mls", rev = "2c7a8669c1492c749c02efd2c5ac45e93e4926a3"} # Expose Mls Extensions (#131)
+de-mls = { git = "https://github.com/vacp2p/de-mls", branch = "develop" }
 double-ratchets = { path = "../double-ratchets" }
 hashgraph-like-consensus = "0.6.0"
 hex = "0.4.3"

--- a/core/conversations/src/conversation/group_v2.rs
+++ b/core/conversations/src/conversation/group_v2.rs
@@ -114,6 +114,41 @@ fn rand_string(n: usize) -> String {
     hex::encode(bytes)
 }
 
+/// One fetched member: `(de-mls member_id, signer_id, key_package_bytes)`.
+type FetchedKeyPackage = (Vec<u8>, String, Vec<u8>);
+
+/// Fetch and dedupe each signer's key package, reading its de-mls member id from
+/// the KP leaf credential (de-mls matches by credential, not signer id). Errors
+/// if any member has no key package, before any are admitted.
+fn fetch_key_packages<S: ExternalServices>(
+    service_ctx: &ServiceContext<S>,
+    members: &[IdentIdRef],
+) -> Result<Vec<FetchedKeyPackage>, ChatError> {
+    let mut seen = std::collections::HashSet::new();
+    let mut invites = Vec::new();
+    for member in members
+        .iter()
+        .copied()
+        .filter(|m| seen.insert(m.as_str().to_string()))
+    {
+        let kp_bytes = service_ctx
+            .registry
+            .retrieve(member.as_str())
+            .map_err(ChatError::generic)?
+            .ok_or_else(|| ChatError::generic("No key package"))?;
+        let key_package_in = KeyPackageIn::tls_deserialize(&mut kp_bytes.as_slice())?;
+        let keypkg =
+            key_package_in.validate(service_ctx.mls_provider.crypto(), ProtocolVersion::Mls10)?;
+        let member_id = keypkg
+            .leaf_node()
+            .credential()
+            .serialized_content()
+            .to_vec();
+        invites.push((member_id, member.to_string(), kp_bytes));
+    }
+    Ok(invites)
+}
+
 fn group_config<S: ExternalServices>(
     cx: &mut ServiceContext<S>,
     name: &str,
@@ -167,6 +202,62 @@ impl GroupV2Convo {
 
         convo.init(service_ctx)?;
 
+        Ok(convo)
+    }
+
+    /// Found a group with its initial members admitted in one genesis commit —
+    /// one welcome for all, settled and stewarding from epoch 1, no consensus
+    /// round (unlike [`Self::new`] + `add_member`). `after_op` routes the genesis
+    /// welcome to each founder's InboxV2.
+    ///
+    /// Assumes `members` is already resolved and deduped, and excludes the
+    /// creator. An integrator that can't guarantee that should filter first, the
+    /// way `add_member` dedups against live membership.
+    pub fn new_with_members<S: ExternalServices>(
+        service_ctx: &mut ServiceContext<S>,
+        name: &str,
+        desc: &str,
+        members: &[IdentIdRef],
+    ) -> Result<Self, ChatError> {
+        let convo_id = rand_string(5);
+        let group_config = group_config(service_ctx, name, desc);
+        let invites = fetch_key_packages(service_ctx, members)?;
+        // `(member_id, key_package_bytes)` slices for the call.
+        let founders: Vec<(&[u8], &[u8])> = invites
+            .iter()
+            .map(|(member_id, _, kp)| (member_id.as_slice(), kp.as_slice()))
+            .collect();
+        let conversation = Conversation::create_with_members(
+            &convo_id,
+            &member_id(service_ctx),
+            &service_ctx.mls_provider,
+            service_ctx.mls_identity.get_credential(),
+            &group_config,
+            &service_ctx.mls_identity,
+            &make_consensus(),
+            make_scoring(),
+            service_ctx.demls_clock.clone(),
+            rand_app_id(),
+            service_ctx.demls_config.clone(),
+            &founders,
+        )?;
+        drop(founders);
+
+        // Route the genesis welcome to each founder's signer id.
+        let pending_invites = invites
+            .into_iter()
+            .map(|(member_id, signer_id, _)| (member_id, signer_id))
+            .collect();
+        let mut convo = GroupV2Convo {
+            convo_id,
+            conversation,
+            pending_invites,
+            commit_anchor: None,
+            sync_anchor: None,
+            buffered_anchor: None,
+        };
+        convo.init(service_ctx)?;
+        convo.after_op(service_ctx)?;
         Ok(convo)
     }
 
@@ -327,51 +418,14 @@ where
         service_ctx: &mut ServiceContext<S>,
         members: &[IdentIdRef],
     ) -> Result<(), ChatError> {
-        // Dedup the requested signers up front: an account can resolve to the
-        // same signer twice, or a caller can repeat one, and a duplicate would
-        // otherwise cost a redundant key-package fetch here and a second Add
-        // proposal for a member already being added in this batch.
-        let mut seen = std::collections::HashSet::new();
-        let members: Vec<IdentIdRef> = members
-            .iter()
-            .copied()
-            .filter(|m| seen.insert(m.as_str().to_string()))
-            .collect();
+        // Fetch every signer's key package + de-mls member id up front (deduped),
+        // failing before any proposal opens if one has no key package.
+        let invites = fetch_key_packages(service_ctx, members)?;
 
-        // Fetch and validate every key package before proposing any add, so a
-        // member with no key package fails the call before it opens proposals
-        // for the others. Members are signer ids; the de-mls member id must
-        // match the id of the IdentityProvider that generated the key package
-        // (its MLS leaf credential content — de-mls matches members by
-        // credential), so it is read from the fetched key package rather than
-        // assumed equal to the signer id.
-        let mut invites = Vec::with_capacity(members.len());
-        for member in &members {
-            let kp_bytes = service_ctx
-                .registry
-                .retrieve(member.as_str())
-                .map_err(ChatError::generic)?
-                .ok_or_else(|| ChatError::generic("No key package"))?;
-            let key_package_in = KeyPackageIn::tls_deserialize(&mut kp_bytes.as_slice())?;
-            let keypkg = key_package_in
-                .validate(service_ctx.mls_provider.crypto(), ProtocolVersion::Mls10)?;
-            let member_id = keypkg
-                .leaf_node()
-                .credential()
-                .serialized_content()
-                .to_vec();
-            invites.push((member_id, member.to_string(), kp_bytes));
-        }
-
-        // pending_invites drives welcome delivery: after_op forwards a welcome
-        // only to a joiner recorded here. Record a member only if de-mls will
-        // actually propose its add — recording one it silently drops strands an
-        // entry that a later re-join can match, firing a spurious duplicate
-        // welcome. de-mls drops self and members already in the group; and since
-        // add_member only opens a proposal, the committed roster won't reflect a
-        // member added earlier in this same loop, so the set tracks those too.
-        // Seed it with the roster and self, insert as we go, and one check
-        // covers all three.
+        // pending_invites routes the welcome, so only record a member de-mls
+        // will actually add — else a stranded entry fires a spurious welcome
+        // later. The roster (members + self, plus adds from this loop) skips the
+        // ones de-mls would drop.
         let mut roster: std::collections::HashSet<Vec<u8>> =
             self.conversation.members()?.into_iter().collect();
         roster.insert(self.conversation.member_id_bytes().to_vec());

--- a/core/conversations/src/conversation/group_v2.rs
+++ b/core/conversations/src/conversation/group_v2.rs
@@ -93,6 +93,12 @@ pub struct GroupV2Convo {
     /// (the joiner's leaf credential content, read from its key package) paired
     /// with the signer id its welcome is delivered to.
     pending_invites: Vec<(Vec<u8>, String)>,
+    /// Liveness anchors: each records when its condition was first seen so we
+    /// wait a window before acting. `None` when the condition is inactive. See
+    /// [`Self::drive_liveness`].
+    commit_anchor: Option<Duration>,
+    sync_anchor: Option<Duration>,
+    buffered_anchor: Option<Duration>,
 }
 
 impl std::fmt::Debug for GroupV2Convo {
@@ -154,6 +160,9 @@ impl GroupV2Convo {
             convo_id,
             conversation,
             pending_invites: vec![],
+            commit_anchor: None,
+            sync_anchor: None,
+            buffered_anchor: None,
         };
 
         convo.init(service_ctx)?;
@@ -190,6 +199,9 @@ impl GroupV2Convo {
             convo_id: conv.id().to_string(),
             conversation: conv,
             pending_invites: vec![],
+            commit_anchor: None,
+            sync_anchor: None,
+            buffered_anchor: None,
         };
 
         convo.init(service_ctx)?; // subscribe
@@ -274,6 +286,7 @@ where
         )?;
         self.conversation
             .poll(&service_ctx.mls_provider, &service_ctx.mls_identity);
+        self.drive_liveness(service_ctx);
         let events = self.after_op(service_ctx)?; // route + publish + re-arm, returns events
         Ok(self.outcome_from_events(&events))
     }
@@ -288,6 +301,7 @@ where
             // this convo from its map;
             tracing::warn!(convo = %self.convo_id, "conversation requested teardown");
         }
+        self.drive_liveness(ctx);
         let events = self.after_op(ctx)?; // publish what poll produced + re-arm alarm
         Ok(self.outcome_from_events(&events))
     }
@@ -417,32 +431,158 @@ where
 }
 
 impl GroupV2Convo {
+    /// The window a steward waits before minting its commit candidate: the full
+    /// `commit_inactivity`, or the shorter `recovery_commit_window` in a recovery
+    /// posture. `drive_liveness` and the `after_op` wakeup fold use the same value
+    /// so the scheduled wakeup lands exactly when the window elapses.
+    fn commit_delay<S: ExternalServices>(&self, service_ctx: &ServiceContext<S>) -> Duration {
+        if self.conversation.in_recovery_posture() {
+            service_ctx.demls_liveness.recovery_commit_window
+        } else {
+            service_ctx.demls_liveness.commit_inactivity
+        }
+    }
+
+    /// Fire any liveness trigger whose window has elapsed; call once per poll.
+    /// Each lever's anchor is armed (and cancelled) by a de-mls event in
+    /// [`Self::after_op`], and fired here once its window passes; `after_op`
+    /// folds the armed windows into the wakeup so this runs right when one
+    /// elapses. libchat times these levers by reacting to de-mls events.
+    ///
+    /// - **commit** — armed by `CommitWorkReady`, cancelled by `CommitApplied`.
+    ///   Every steward mints after `commit_inactivity` (`recovery_commit_window`
+    ///   in a recovery posture) and de-mls deterministically selects one, so a
+    ///   silent primary is covered by its candidate's absence. A level backstop
+    ///   (`pending_commit_work`) also arms it, catching a batch that survived a
+    ///   round with no fresh event.
+    /// - **sync-resend** — armed by `SyncResendNeeded`, cancelled by
+    ///   `ConversationSyncObserved`; a backup covers a silent steward after
+    ///   `silent_steward_window`.
+    /// - **buffered-propose** — armed by `UpdateRequestReceived` (or the
+    ///   `pending_buffered_updates` backstop); a backup covers a silent primary's
+    ///   unproposed add/remove after the same window.
+    /// - **recovery** — mint each cycle while Layer-3 recovery is open; opening it
+    ///   is the `ReelectionExhausted` arm in `after_op`.
+    fn drive_liveness<S: ExternalServices>(&mut self, service_ctx: &ServiceContext<S>) {
+        let now = service_ctx.demls_clock.now();
+        let silent = service_ctx.demls_liveness.silent_steward_window;
+        let provider = &service_ctx.mls_provider;
+        let signer = &service_ctx.mls_identity;
+
+        // Commit: level backstop for a batch that survived a round (no fresh
+        // `CommitWorkReady`), then fire once the window elapses.
+        if self.commit_anchor.is_none()
+            && self.conversation.is_steward()
+            && self.conversation.pending_commit_work().is_some()
+        {
+            self.commit_anchor = Some(now);
+        }
+        if let Some(started) = self.commit_anchor
+            && now.saturating_sub(started) >= self.commit_delay(service_ctx)
+        {
+            self.commit_anchor = None;
+            if self.conversation.is_steward()
+                && let Err(e) = self.conversation.commit_now(provider, signer)
+            {
+                tracing::warn!(convo = %self.convo_id, error = %e, "commit_now failed");
+            }
+        }
+
+        // Sync-resend: armed/cancelled by events; fire after the short window.
+        if let Some(started) = self.sync_anchor
+            && now.saturating_sub(started) >= silent
+        {
+            self.sync_anchor = None;
+            if let Err(e) = self.conversation.share_conversation_sync(provider, signer) {
+                tracing::warn!(convo = %self.convo_id, error = %e, "share_conversation_sync failed");
+            }
+        }
+
+        // Buffered-propose: level backstop (a covering proposal expired → the
+        // entry is actionable again with no fresh event), then fire.
+        if self.buffered_anchor.is_none() && self.conversation.pending_buffered_updates() > 0 {
+            self.buffered_anchor = Some(now);
+        }
+        if let Some(started) = self.buffered_anchor
+            && now.saturating_sub(started) >= silent
+        {
+            self.buffered_anchor = None;
+            if let Err(e) = self.conversation.propose_buffered_updates(provider, signer) {
+                tracing::warn!(convo = %self.convo_id, error = %e, "propose_buffered_updates failed");
+            }
+        }
+
+        // Recovery: mint each cycle while Layer-3 recovery is open.
+        if self.conversation.is_in_recovery_mode()
+            && let Err(e) = self.conversation.commit_in_recovery(provider, signer)
+        {
+            tracing::warn!(convo = %self.convo_id, error = %e, "commit_in_recovery failed");
+        }
+    }
+
     fn after_op<S: ExternalServices>(
         &mut self,
         service_ctx: &mut ServiceContext<S>,
     ) -> Result<Vec<ConversationEvent>, ChatError> {
-        // Pull everything first (these are &self, take-all):
+        // Drain events first and react to them before reading outbound/wakeup:
+        // request_recovery below emits its own outbound and arms a de-mls
+        // deadline, so it must run before we snapshot those.
         let events = self.conversation.drain_events();
-        let outbound = self.conversation.drain_outbound(); // Vec<de_mls::session::Outbound>
-        let wakeup = self.conversation.next_wakeup_in();
+        let now = service_ctx.demls_clock.now();
 
-        // 1. Route welcomes for joiners WE invited (event fires on every member
-        //    now). The welcome travels to the joiner's signer id (where its
-        //    InboxV2 listens), not its de-mls member id.
+        // 1. React to events: arm/cancel the liveness anchors drive_liveness
+        //    fires (see its per-lever contract), route welcomes for joiners WE
+        //    invited to their signer id, and open Layer-3 recovery when de-mls's
+        //    internal reelection gives up.
         for evt in &events {
-            if let ConversationEvent::WelcomeReady { welcome, .. } = evt {
-                for joiner in &welcome.joiner_identities {
-                    if let Some(i) = self.pending_invites.iter().position(|(p, _)| p == joiner) {
-                        let (_, signer_id) = self.pending_invites.remove(i);
-                        crate::inbox_v2::invite_user_v2(
-                            &mut service_ctx.ds,
-                            &IdentId::new(signer_id),
-                            welcome,
-                        )?;
+            match evt {
+                ConversationEvent::WelcomeReady { welcome, .. } => {
+                    for joiner in &welcome.joiner_identities {
+                        if let Some(i) = self.pending_invites.iter().position(|(p, _)| p == joiner)
+                        {
+                            let (_, signer_id) = self.pending_invites.remove(i);
+                            crate::inbox_v2::invite_user_v2(
+                                &mut service_ctx.ds,
+                                &IdentId::new(signer_id),
+                                welcome,
+                            )?;
+                        }
                     }
                 }
+                ConversationEvent::CommitWorkReady { .. } => {
+                    // Only a steward commits; a non-steward arming here would just
+                    // schedule a wakeup that drive_liveness clears unused. The
+                    // level backstop re-arms if this member becomes a steward.
+                    if self.conversation.is_steward() {
+                        self.commit_anchor.get_or_insert(now);
+                    }
+                }
+                ConversationEvent::CommitApplied(_) => {
+                    self.commit_anchor = None;
+                }
+                ConversationEvent::UpdateRequestReceived { .. } => {
+                    self.buffered_anchor.get_or_insert(now);
+                }
+                ConversationEvent::SyncResendNeeded => {
+                    self.sync_anchor.get_or_insert(now);
+                }
+                ConversationEvent::ConversationSyncObserved => {
+                    self.sync_anchor = None;
+                }
+                ConversationEvent::ReelectionExhausted => {
+                    if let Err(e) = self
+                        .conversation
+                        .request_recovery(&service_ctx.mls_provider, &service_ctx.mls_identity)
+                    {
+                        tracing::warn!(convo = %self.convo_id, error = %e, "request_recovery failed");
+                    }
+                }
+                _ => {}
             }
         }
+
+        let outbound = self.conversation.drain_outbound(); // Vec<de_mls::session::Outbound>
+        let wakeup = self.conversation.next_wakeup_in();
 
         // 2. Publish
         for out in outbound {
@@ -464,7 +604,22 @@ impl GroupV2Convo {
                 .map_err(ChatError::generic)?;
         }
 
-        // 3. Re-arm the alarm with the conversation's earliest deadline.
+        // 3. Re-arm the alarm at the earliest of de-mls's own deadline and our
+        //    liveness windows. Each anchor folds in the same delay drive_liveness
+        //    used, so the wakeup lands exactly when the window elapses.
+        let silent_window = service_ctx.demls_liveness.silent_steward_window;
+        let liveness_wakeup = [
+            (self.commit_anchor, self.commit_delay(service_ctx)),
+            (self.sync_anchor, silent_window),
+            (self.buffered_anchor, silent_window),
+        ]
+        .into_iter()
+        .filter_map(|(anchor, delay)| anchor.map(|s| (s + delay).saturating_sub(now)))
+        .min();
+        let wakeup = match (wakeup, liveness_wakeup) {
+            (Some(a), Some(b)) => Some(a.min(b)),
+            (a, b) => a.or(b),
+        };
         if let Some(d) = wakeup {
             service_ctx
                 .wakeup_service

--- a/core/conversations/src/core.rs
+++ b/core/conversations/src/core.rs
@@ -2,7 +2,7 @@ use crate::causal_history::{CausalHistoryStore, MissingMessage};
 use crate::conversation::{
     ConversationIdRef, DirectV1Convo, GroupV1Convo, GroupV2Convo, Identified,
 };
-use crate::service_context::{ExternalServices, ServiceContext};
+use crate::service_context::{ExternalServices, LivenessTimings, ServiceContext};
 use crate::types::ConvoMetadata;
 use crate::{
     DeliveryService, GroupV2Clock, GroupV2Config, IdentityProvider, RegistrationService,
@@ -112,6 +112,13 @@ where
         self.services.demls_config = config;
     }
 
+    /// Overrides the app-owned GroupV2 liveness windows (commit-inactivity,
+    /// silent-steward, recovery-commit). Applies to conversations
+    /// created/joined after the call.
+    pub fn set_group_v2_liveness_timings(&mut self, timings: LivenessTimings) {
+        self.services.demls_liveness = timings;
+    }
+
     /// Builds the inbox/account/MLS/causal state, subscribes both inbound
     /// addresses, and assembles the service bundle — shared by both constructors.
     fn assemble(
@@ -150,6 +157,7 @@ where
                 wakeup_service,
                 demls_clock: GroupV2Clock::default(),
                 demls_config: GroupV2Config::default(),
+                demls_liveness: LivenessTimings::default(),
             },
             pq_inbox,
             cached_convos: HashMap::new(),

--- a/core/conversations/src/core.rs
+++ b/core/conversations/src/core.rs
@@ -265,6 +265,21 @@ impl<'a, S: ExternalServices + 'static> Core<S> {
         Ok(convo_id)
     }
 
+    /// Found a GroupV2 conversation with its initial members in one genesis
+    /// commit, unlike [`Self::create_group_convo_v2`] which opens a proposal per
+    /// member.
+    pub fn create_group_with_members_v2(
+        &mut self,
+        participants: &[IdentIdRef],
+        name: &str,
+        desc: &str,
+    ) -> Result<ConversationId, ChatError> {
+        let convo = GroupV2Convo::new_with_members(&mut self.services, name, desc, participants)?;
+        let convo_id = convo.id().to_string();
+        self.register_convo(ConvoTypeOwned::Group(Box::new(convo)))?;
+        Ok(convo_id)
+    }
+
     /// Add members to an existing group conversation.
     pub fn group_add_member(
         &mut self,

--- a/core/conversations/src/lib.rs
+++ b/core/conversations/src/lib.rs
@@ -27,7 +27,7 @@ pub use errors::ChatError;
 pub use outcomes::{
     Content, ConversationClass, ConvoOutcome, InboxOutcome, NewConversation, PayloadOutcome,
 };
-pub use service_context::ExternalServices;
+pub use service_context::{ExternalServices, LivenessTimings};
 pub use service_traits::{DeliveryService, RegistrationService, WakeupService};
 pub use shared_traits::{IdentId, IdentIdRef, IdentityProvider};
 pub use storage::{ChatStore, ConversationKind};

--- a/core/conversations/src/service_context.rs
+++ b/core/conversations/src/service_context.rs
@@ -1,5 +1,7 @@
 //! Bundles the services a conversation operation needs into one [`ServiceContext`].
 
+use std::time::Duration;
+
 use crypto::Identity;
 use storage::ChatStore;
 
@@ -9,6 +11,34 @@ use crate::conversation::GroupV2Clock;
 use crate::inbox_v2::{MlsEphemeralPqProvider, MlsIdentityProvider};
 use crate::service_traits::WakeupService;
 use crate::{DeliveryService, RegistrationService};
+
+/// App-owned durations for the GroupV2 liveness policy; the integrator times
+/// these itself (see `GroupV2Convo::drive_liveness`). Distinct from the de-mls
+/// `ConversationConfig` — the app's to tune, not protocol wire state.
+/// `commit_inactivity` must stay above the de-mls `consensus_timeout` so a
+/// batch's votes resolve before it is committed.
+#[derive(Debug, Clone, Copy)]
+pub struct LivenessTimings {
+    /// How long the epoch steward collects approved work before committing it.
+    pub commit_inactivity: Duration,
+    /// The short window a backup waits before covering a silent epoch steward's
+    /// in-epoch propose / sync-resend (the work is already visible to all).
+    pub silent_steward_window: Duration,
+    /// The shorter commit window used while in a recovery posture (a reelection
+    /// retry round, or one that just landed) in place of the full
+    /// `commit_inactivity` wait, so a recovering group settles faster.
+    pub recovery_commit_window: Duration,
+}
+
+impl Default for LivenessTimings {
+    fn default() -> Self {
+        Self {
+            commit_inactivity: Duration::from_secs(60),
+            silent_steward_window: Duration::from_secs(30),
+            recovery_commit_window: Duration::from_secs(30),
+        }
+    }
+}
 
 /// Bundles the external service types (`DS`, `RS`, `CS`) behind one `S`. The
 /// `(DS, RS, CS)` tuple impl lets them still be supplied separately.
@@ -51,4 +81,6 @@ pub(crate) struct ServiceContext<S: ExternalServices> {
     /// create/join. The creator's phase durations reach joiners inside the
     /// welcome's `ConversationSync`.
     pub(crate) demls_config: de_mls::ConversationConfig,
+    /// App-owned liveness windows the driving loop times itself.
+    pub(crate) demls_liveness: LivenessTimings,
 }

--- a/core/integration_tests_core/src/test_client.rs
+++ b/core/integration_tests_core/src/test_client.rs
@@ -1,6 +1,6 @@
 use crate::test_ident::TestIdent;
 use libchat::{ConversationId, Core, IdentityProvider, PayloadOutcome};
-use libchat::{GroupV2Clock, GroupV2Config};
+use libchat::{GroupV2Clock, GroupV2Config, LivenessTimings};
 use shared_traits::IdentId;
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -154,6 +154,7 @@ impl<const N: usize> TestHarness<N> {
                     .unwrap();
             core_client.set_group_v2_clock(GroupV2Clock::Mock(ws.clock()));
             core_client.set_group_v2_config(fast_group_v2_config());
+            core_client.set_group_v2_liveness_timings(fast_liveness_timings());
 
             let client = TestClient::init(core_client);
 
@@ -298,13 +299,21 @@ impl TestHarness<4> {
 /// defaults converge too slowly for the harness's step sizes.
 fn fast_group_v2_config() -> GroupV2Config {
     GroupV2Config {
-        commit_inactivity_duration: Duration::from_millis(50),
         freeze_duration: Duration::from_millis(20),
         voting_delay: Duration::from_millis(30),
-        election_voting_delay: Duration::from_millis(30),
         consensus_timeout: Duration::from_millis(150),
         proposal_expiration: Duration::from_millis(2000),
         ..GroupV2Config::default()
+    }
+}
+
+/// Millisecond liveness windows so the app-side commit/takeover timers fire in
+/// test time; the production defaults are tens of seconds.
+fn fast_liveness_timings() -> LivenessTimings {
+    LivenessTimings {
+        commit_inactivity: Duration::from_millis(50),
+        silent_steward_window: Duration::from_millis(40),
+        recovery_commit_window: Duration::from_millis(30),
     }
 }
 

--- a/crates/generic-chat/src/builder.rs
+++ b/crates/generic-chat/src/builder.rs
@@ -1,6 +1,8 @@
 use components::EphemeralRegistry;
 use crossbeam_channel::Receiver;
-use libchat::{ChatError, ChatStorage, GroupV2Config, RegistrationService, StorageConfig};
+use libchat::{
+    ChatError, ChatStorage, GroupV2Config, LivenessTimings, RegistrationService, StorageConfig,
+};
 use logos_account::AccountDirectory;
 use storage::ChatStore;
 
@@ -9,6 +11,14 @@ use crate::client::ChatClient;
 use crate::delegate::DelegateSigner;
 use crate::errors::ClientError;
 use crate::event::Event;
+
+/// GroupV2 tuning carried from the builder to the client: the de-mls protocol
+/// config plus the app-owned liveness windows the driving loop times itself.
+#[derive(Default)]
+pub struct GroupV2Settings {
+    pub config: GroupV2Config,
+    pub liveness: LivenessTimings,
+}
 
 /// Marker for a builder field that has not been configured; the corresponding
 /// component will be filled in with a sensible default when `build()` is called.
@@ -20,7 +30,7 @@ pub struct ChatClientBuilder<I = Unset, T = Unset, R = Unset, S = Unset> {
     transport: T,
     registration: R,
     storage: S,
-    group_v2: Option<GroupV2Config>,
+    group_v2: Option<GroupV2Settings>,
 }
 
 impl ChatClientBuilder {
@@ -106,7 +116,19 @@ impl<I, T, R, S> ChatClientBuilder<I, T, R, S> {
     /// travel to joiners with the welcome and overwrite theirs (vote delays
     /// and policy fields stay local).
     pub fn group_v2_config(mut self, config: GroupV2Config) -> Self {
-        self.group_v2 = Some(config);
+        self.group_v2
+            .get_or_insert_with(GroupV2Settings::default)
+            .config = config;
+        self
+    }
+
+    /// App-owned liveness windows (commit-inactivity, silent-steward,
+    /// recovery-commit) the GroupV2 driving loop times for its conversations.
+    /// Defaults to [`LivenessTimings::default`].
+    pub fn group_v2_liveness_timings(mut self, timings: LivenessTimings) -> Self {
+        self.group_v2
+            .get_or_insert_with(GroupV2Settings::default)
+            .liveness = timings;
         self
     }
 }

--- a/crates/generic-chat/src/client.rs
+++ b/crates/generic-chat/src/client.rs
@@ -6,9 +6,11 @@ use components::{ThreadedWakeupService, WakeupEvent};
 use crossbeam_channel::{Receiver, Sender, select};
 use crypto::Ed25519VerifyingKey;
 use libchat::{
-    ConversationId, ConvoMetadata, ConvoOutcome, Core, DeliveryService, GroupV2Config, IdentId,
-    IdentIdRef, InboxOutcome, PayloadOutcome, RegistrationService,
+    ConversationId, ConvoMetadata, ConvoOutcome, Core, DeliveryService, IdentId, IdentIdRef,
+    InboxOutcome, PayloadOutcome, RegistrationService,
 };
+
+use crate::builder::GroupV2Settings;
 use logos_account::{AccountDirectory, resolve_device_ids};
 use parking_lot::Mutex;
 use storage::ChatStore;
@@ -113,7 +115,7 @@ where
         mut transport: T,
         reg: R,
         storage: S,
-        group_v2: Option<GroupV2Config>,
+        group_v2: Option<GroupV2Settings>,
     ) -> Result<(Self, Receiver<Event>), ClientError> {
         let inbound = transport.inbound();
 
@@ -122,8 +124,9 @@ where
         let directory = reg.clone();
         let ident = DelegateIdentity::new(ident, &account);
         let mut core = Core::new_with_name(ident, transport, reg, wakeup_service, storage)?;
-        if let Some(config) = group_v2 {
-            core.set_group_v2_config(config);
+        if let Some(settings) = group_v2 {
+            core.set_group_v2_config(settings.config);
+            core.set_group_v2_liveness_timings(settings.liveness);
         }
         Ok(Self::spawn(core, directory, account, inbound, wakeup_rx))
     }

--- a/crates/generic-chat/src/client.rs
+++ b/crates/generic-chat/src/client.rs
@@ -214,6 +214,24 @@ where
             .map_err(Into::into)
     }
 
+    /// Found a group with its initial members admitted in one genesis commit —
+    /// every founder joins from a single welcome, no per-member proposal round
+    /// (unlike [`Self::create_group_conversation`]). Each account must have a
+    /// published key package.
+    pub fn create_group_with_members(
+        &mut self,
+        accounts: &[AccountAddressRef],
+        metadata: GroupMetadata,
+    ) -> Result<ConversationId, ClientError> {
+        let signers = self.signers_from_accounts(accounts)?;
+        let signer_refs: Vec<IdentIdRef> = signers.iter().collect();
+
+        self.core
+            .lock()
+            .create_group_with_members_v2(&signer_refs, &metadata.name, &metadata.desc)
+            .map_err(Into::into)
+    }
+
     /// Add accounts' devices to an existing group conversation. The add is
     /// staged as an MLS proposal and merged by the group's next commit (driven
     /// asynchronously by the wakeup loop); each joiner's welcome is sent when

--- a/crates/generic-chat/src/lib.rs
+++ b/crates/generic-chat/src/lib.rs
@@ -5,7 +5,7 @@ mod delivery_in_process;
 mod errors;
 mod event;
 
-pub use builder::{ChatClientBuilder, Unset};
+pub use builder::{ChatClientBuilder, GroupV2Settings, Unset};
 pub use client::{ChatClient, GroupMember, GroupMetadata, Transport};
 pub use delegate::DelegateSigner;
 pub use delivery_in_process::{InProcessDelivery, MessageBus};
@@ -15,7 +15,8 @@ pub use event::{Event, MessageSender};
 // Re-export types callers need to interact with ChatClient.
 pub use libchat::{
     AddressedEnvelope, ChatStore, ConversationClass, ConversationId, ConvoMetadata,
-    DeliveryService, GroupV2Config, IdentityProvider, RegistrationService, StorageConfig,
+    DeliveryService, GroupV2Config, IdentityProvider, LivenessTimings, RegistrationService,
+    StorageConfig,
 };
 // The directory trait bounds ChatClient's registry parameter, so callers
 // writing code generic over ChatClient need it too.

--- a/crates/generic-chat/tests/group_v2.rs
+++ b/crates/generic-chat/tests/group_v2.rs
@@ -12,7 +12,7 @@ use libchat::ChatStorage;
 use logos_account::TestLogosAccount;
 use logos_generic_chat::{
     ChatClient, ChatClientBuilder, ConversationClass, DelegateSigner, Event, GroupMetadata,
-    GroupV2Config, InProcessDelivery, MessageBus,
+    GroupV2Config, InProcessDelivery, LivenessTimings, MessageBus,
 };
 
 /// Metadata for a group these tests create without a name or description.
@@ -24,13 +24,21 @@ fn unnamed_group() -> GroupMetadata {
 /// in test time; the library defaults wait 60s before committing an add.
 fn fast_group_v2_config() -> GroupV2Config {
     GroupV2Config {
-        commit_inactivity_duration: Duration::from_millis(50),
         freeze_duration: Duration::from_millis(20),
         voting_delay: Duration::from_millis(30),
-        election_voting_delay: Duration::from_millis(30),
         consensus_timeout: Duration::from_millis(150),
         proposal_expiration: Duration::from_millis(2000),
         ..GroupV2Config::default()
+    }
+}
+
+/// Millisecond liveness windows so the app-side commit/takeover timers fire in
+/// test time; the production defaults are tens of seconds.
+fn fast_liveness_timings() -> LivenessTimings {
+    LivenessTimings {
+        commit_inactivity: Duration::from_millis(50),
+        silent_steward_window: Duration::from_millis(40),
+        recovery_commit_window: Duration::from_millis(30),
     }
 }
 
@@ -63,6 +71,7 @@ fn create_test_client_with(
         .transport(InProcessDelivery::new(message_bus))
         .registration(reg)
         .group_v2_config(config)
+        .group_v2_liveness_timings(fast_liveness_timings())
         .build()
         .expect("client create");
     let addr = client.addr().to_string();

--- a/crates/generic-chat/tests/group_v2.rs
+++ b/crates/generic-chat/tests/group_v2.rs
@@ -51,7 +51,12 @@ fn create_test_client(
     message_bus: MessageBus,
     reg: EphemeralRegistry,
 ) -> (TestClient, Receiver<Event>, String) {
-    create_test_client_with(message_bus, reg, fast_group_v2_config())
+    create_test_client_with(
+        message_bus,
+        reg,
+        fast_group_v2_config(),
+        fast_liveness_timings(),
+    )
 }
 
 /// [`create_test_client`] with explicit GroupV2 timers, for a test that needs
@@ -60,6 +65,7 @@ fn create_test_client_with(
     message_bus: MessageBus,
     mut reg: EphemeralRegistry,
     config: GroupV2Config,
+    timings: LivenessTimings,
 ) -> (TestClient, Receiver<Event>, String) {
     let account = TestLogosAccount::new();
     let delegate = DelegateSigner::random();
@@ -71,7 +77,7 @@ fn create_test_client_with(
         .transport(InProcessDelivery::new(message_bus))
         .registration(reg)
         .group_v2_config(config)
-        .group_v2_liveness_timings(fast_liveness_timings())
+        .group_v2_liveness_timings(timings)
         .build()
         .expect("client create");
     let addr = client.addr().to_string();
@@ -227,6 +233,45 @@ fn group_v2_three_members() {
     assert_eq!(pax.list_conversations().unwrap().len(), 1);
 }
 
+/// Genesis founding: saro founds a group with raya and pax admitted in one
+/// commit — both join from the single welcome, no per-member proposal round.
+#[test]
+fn group_v2_founds_with_members() {
+    let bus = MessageBus::default();
+    let reg = EphemeralRegistry::new();
+
+    let (mut saro, _saro_events, saro_addr) = create_test_client(bus.clone(), reg.clone());
+    let (mut raya, raya_events, raya_addr) = create_test_client(bus.clone(), reg.clone());
+    let (mut pax, pax_events, pax_addr) = create_test_client(bus.clone(), reg.clone());
+
+    let convo_id = saro
+        .create_group_with_members(&[&raya_addr, &pax_addr], unnamed_group())
+        .expect("saro founds group with members");
+
+    // Both founders join from the single genesis welcome.
+    let raya_convo_id = wait_for_group_started(&raya_events, "raya joins at genesis");
+    let pax_convo_id = wait_for_group_started(&pax_events, "pax joins at genesis");
+    assert_eq!(raya_convo_id, convo_id);
+    assert_eq!(pax_convo_id, convo_id);
+
+    // All three rosters converge on the three founding accounts.
+    let all = [saro_addr.as_str(), raya_addr.as_str(), pax_addr.as_str()];
+    wait_for_members(&mut saro, &convo_id, &all);
+    wait_for_members(&mut raya, &raya_convo_id, &all);
+    wait_for_members(&mut pax, &pax_convo_id, &all);
+
+    // Messaging works across the founded group.
+    saro.send_message(&convo_id, b"founded").unwrap();
+    assert_eq!(
+        wait_for_message(&raya_events, b"founded").as_deref(),
+        Some(saro_addr.as_str())
+    );
+    assert_eq!(
+        wait_for_message(&pax_events, b"founded").as_deref(),
+        Some(saro_addr.as_str())
+    );
+}
+
 /// The same two peers are invited to several groups at once. Each installation
 /// registers a single key package, so admitting it to more than one group only
 /// works if that key package survives a join — a regression guard for the
@@ -304,13 +349,18 @@ fn invited_member_is_pending_until_the_group_commits() {
     let reg = EphemeralRegistry::new();
 
     // A commit window far longer than the assertions below, so the add provably
-    // cannot merge while they run.
-    let deferred_commit = GroupV2Config {
-        commit_inactivity_duration: Duration::from_secs(30),
-        ..fast_group_v2_config()
+    // cannot merge while they run. The commit timer is app-owned now, so the
+    // window lives in LivenessTimings, not the de-mls config.
+    let deferred_commit = LivenessTimings {
+        commit_inactivity: Duration::from_secs(30),
+        ..fast_liveness_timings()
     };
-    let (mut saro, _saro_events, saro_addr) =
-        create_test_client_with(bus.clone(), reg.clone(), deferred_commit);
+    let (mut saro, _saro_events, saro_addr) = create_test_client_with(
+        bus.clone(),
+        reg.clone(),
+        fast_group_v2_config(),
+        deferred_commit,
+    );
     let (_raya, _raya_events, raya_addr) = create_test_client(bus.clone(), reg.clone());
 
     let convo_id = saro


### PR DESCRIPTION
Two commits, kept separate:

**Drive liveness from de-mls events.** de-mls no longer keeps liveness timers — it emits events (`CommitWorkReady`, `UpdateRequestReceived`, `SyncResendNeeded`/`ConversationSyncObserved`, `ReelectionExhausted`) and the integrator decides when to act. This wires that on the libchat side: react to the event, arm a window, fire the trigger.

**Found a group with its members.** New `create_group_with_members` admits the founders in one genesis commit — one welcome, settled and stewarding from epoch 1, no consensus round — next to the existing proposal-per-member `create_group_conversation`.

Worth deciding on your side:

- `drive_liveness` collects every lever's anchor in one pass to keep the example simple. Split it per-lever, or drive off real presence/transport signals instead of blind timers, however fits you.
- Welcome delivery is inviter-only: if the inviter is offline when the commit lands, the joiner waits for a re-invite. A steward fallback would close that.
- `new_with_members` assumes an already-resolved, deduped participant list (no self). Filter first if you can't guarantee it, the way `add_member` dedups against live membership.
