### PR TITLE
ci: switch the Nix cache to setup-nix-cache-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,21 +49,17 @@ jobs:
 
   smoketest:
     name: Smoketest
+    environment: ${{ github.ref == 'refs/heads/main' && 'public-cache' || '' }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v31
+      - uses: logos-co/setup-nix-cache-action@v1
         with:
-          nix_version: 2.34.6
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-      - uses: nix-community/cache-nix-action@v6
-        with:
-          primary-key: nix-${{ runner.os }}-fixtest-${{ hashFiles('flake.nix', 'flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-
+          attic-token-ci: ${{ secrets.ATTIC_TOKEN_CI }}
+          attic-token-public: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
       - name: Build logos-delivery
         run: nix build .#logos-delivery --print-build-logs
       # Build and run chat-cli through the dev shell so it links against the

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,11 @@
 {
   description = "libchat - Logos Chat cryptographic library";
 
+  nixConfig = {
+    extra-substituters = [ "https://cache.nix.logos.co/public" ];
+    extra-trusted-public-keys = [ "public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU=" ];
+  };
+
   inputs = {
     # nixos-unstable-small has both crates.io UA fixes (NixOS/nixpkgs#512735,
     # NixOS/nixpkgs#524985); nixos-unstable hasn't caught up yet as of 2026-05-28.


### PR DESCRIPTION
Same as logos-co/logos-chat-module#57 and logos-co/logos-delivery-module#69, using [`setup-nix-cache-action@v1`](https://github.com/logos-co/setup-nix-cache-action). Replaces `cache-nix-action` (per-runner GitHub cache) with the shared Attic cache; drops the `nix_version` pin since the action installs its own Nix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)