### PR TITLE
Re-enable XWING

### DIFF
--- a/core/conversations/src/conversation/group_v1.rs
+++ b/core/conversations/src/conversation/group_v1.rs
@@ -47,7 +47,7 @@ impl std::fmt::Debug for GroupV1Convo {
 impl GroupV1Convo {
     // Create a new conversation with the creator as the only participant.
     pub fn new<S: ExternalServices>(cx: &mut ServiceContext<S>) -> Result<Self, ChatError> {
-        let config = Self::mls_create_config(cx);
+        let config = Self::mls_create_config();
         let mls_group = MlsGroup::new(
             &cx.mls_provider,
             &cx.mls_identity,
@@ -114,9 +114,9 @@ impl GroupV1Convo {
         Ok(())
     }
 
-    fn mls_create_config<S: ExternalServices>(cx: &mut ServiceContext<S>) -> MlsGroupCreateConfig {
+    fn mls_create_config() -> MlsGroupCreateConfig {
         MlsGroupCreateConfig::builder()
-            .ciphersuite(cx.mls_provider.crypto().supported_ciphersuites()[0])
+            .ciphersuite(crate::inbox_v2::CIPHER_SUITE)
             .use_ratchet_tree_extension(true) // This is handy for now, until there is central store for this data
             .build()
     }

--- a/core/conversations/src/conversation/group_v2.rs
+++ b/core/conversations/src/conversation/group_v2.rs
@@ -23,7 +23,6 @@ use openmls::extensions::{Extension, Extensions, UnknownExtension};
 use openmls::group::MlsGroupCreateConfig;
 use openmls::prelude::tls_codec::Deserialize as _;
 use openmls::prelude::{KeyPackageIn, OpenMlsProvider as _, ProtocolVersion};
-use openmls_traits::crypto::OpenMlsCrypto;
 use prost::Message;
 use shared_traits::{IdentId, IdentIdRef};
 use std::sync::Arc;
@@ -108,11 +107,7 @@ fn rand_string(n: usize) -> String {
     hex::encode(bytes)
 }
 
-fn group_config<S: ExternalServices>(
-    cx: &mut ServiceContext<S>,
-    name: &str,
-    desc: &str,
-) -> MlsGroupCreateConfig {
+fn group_config(name: &str, desc: &str) -> MlsGroupCreateConfig {
     let meta = ConvoMetaInfo::new(name, desc);
 
     let extensions = Extensions::from_vec(vec![Extension::Unknown(
@@ -122,7 +117,7 @@ fn group_config<S: ExternalServices>(
     .expect("failed to create extensions");
 
     MlsGroupCreateConfig::builder()
-        .ciphersuite(cx.mls_provider.crypto().supported_ciphersuites()[0])
+        .ciphersuite(crate::inbox_v2::CIPHER_SUITE)
         .capabilities(capabilities_with_group_metadata())
         .use_ratchet_tree_extension(true) // Embed the ratchet tree in the Welcome so joiners can build the group
         .with_group_context_extensions(extensions)
@@ -136,7 +131,7 @@ impl GroupV2Convo {
         desc: &str,
     ) -> Result<Self, ChatError> {
         let convo_id = rand_string(5);
-        let group_config = group_config(service_ctx, name, desc);
+        let group_config = group_config(name, desc);
         let conversation = Conversation::create(
             &convo_id,
             &member_id(service_ctx),

--- a/core/conversations/src/inbox_v2.rs
+++ b/core/conversations/src/inbox_v2.rs
@@ -26,9 +26,8 @@ use crate::service_context::{ExternalServices, ServiceContext};
 use crate::utils::{blake2b_hex, hash_size};
 use crate::{AddressedEnvelope, IdentId, IdentIdRef, IdentityProvider};
 
-// Downgraded from MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519 until demls accepts an external provider
 pub(crate) const CIPHER_SUITE: Ciphersuite =
-    Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+    Ciphersuite::MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519;
 
 // Define unique Identifiers derivations used in InboxV2
 fn delivery_address_for(ident_id: IdentIdRef) -> String {


### PR DESCRIPTION
## Problem 

The Ciphersuite was previously downgraded to `MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519` awaiting support from DeMLS for XWING.

## Solution

Now that DeMLS accepts the MlsProvider externally, this PR enables `MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519` once again.

