### PR TITLE
fix(build): re-run logos-delivery build script when the native lib apears

### DIFF
--- a/bin/chat-cli/README.md
+++ b/bin/chat-cli/README.md
@@ -4,8 +4,15 @@ A terminal chat application built on top of libchat. End-to-end encrypted messag
 
 ## Building
 
-[logos-delivery](https://github.com/logos-messaging/logos-delivery) is exposed as a Nix package.
-Build it once, then point `LOGOS_DELIVERY_LIB_DIR` at the result:
+`chat-cli` links the native [logos-delivery](https://github.com/logos-messaging/logos-delivery)
+library. The dev shell builds it and sets `LOGOS_DELIVERY_LIB_DIR` for you:
+
+```bash
+nix develop
+cargo build --release -p chat-cli
+```
+
+Or build the library yourself and point `LOGOS_DELIVERY_LIB_DIR` at it:
 
 ```bash
 nix build .#logos-delivery

--- a/extensions/logos-delivery-rust/build.rs
+++ b/extensions/logos-delivery-rust/build.rs
@@ -94,6 +94,11 @@ fn resolve_lib_dir(dir: &str) -> Option<PathBuf> {
         let manifest = std::env::var("CARGO_MANIFEST_DIR").ok()?;
         Path::new(&find_flake_root(&manifest)?).join(path)
     };
+    // Re-run once the lib appears, so build order (nix build vs. cargo) is free.
+    println!("cargo:rerun-if-changed={}", anchored.display());
+    if let Some(parent) = anchored.parent() {
+        println!("cargo:rerun-if-changed={}", parent.display());
+    }
     anchored.canonicalize().ok()
 }
 
@@ -149,8 +154,11 @@ fn nix_build_logos_delivery() -> Option<String> {
 
     println!("cargo:rerun-if-changed={flake_root}/flake.lock");
 
+    // Enable flakes inline so the fallback works without global nix.conf setup.
     let output = Command::new("nix")
         .args([
+            "--extra-experimental-features",
+            "nix-command flakes",
             "build",
             ".#logos-delivery",
             "--no-link",


### PR DESCRIPTION
Fixes `chat-cli` failing to link with undefined `_logosdelivery_*` symbols when the native lib is built after the first `cargo build`. The build script now watches the `LOGOS_DELIVERY_LIB_DIR` path so it re-runs once the lib appears, making build order irrelevant; the fallback `nix` build also enables flakes inline, and the `README` leads with nix develop.