### PR TITLE
Support iOS targets in the logos-delivery transport build

### DIFF
--- a/extensions/logos-delivery-rust/build.rs
+++ b/extensions/logos-delivery-rust/build.rs
@@ -20,13 +20,13 @@ fn main() {
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
 
     match target_os.as_str() {
-        "macos" | "linux" => {}
+        "macos" | "linux" | "ios" => {}
         other => panic!("unsupported OS for logos-delivery transport: {other}"),
     }
 
     // Two linking modes, because dev builds and *distributable* builds want
     // opposite things out of the library's install name / soname.
-    if relocatable() {
+    if relocatable() || target_os == "ios" {
         // Distribution: link the shipped library in place and leave its
         // relocatable name (@rpath on macOS, $ORIGIN soname on Linux) intact,
         // so the consumer can copy it into its own bundle and resolve it from
@@ -51,7 +51,16 @@ fn main() {
         println!("cargo:rustc-link-search=native={out_dir}");
     }
 
-    println!("cargo:rustc-link-lib=dylib=logosdelivery");
+    if target_os == "ios" {
+        // iOS apps cannot ship loose dylibs the way an APK can, so the delivery
+        // node is linked as a static archive. rln has to be named explicitly:
+        // with no shared library there is no rpath to resolve it transitively.
+        println!("cargo:rustc-link-lib=static=logosdelivery");
+        println!("cargo:rustc-link-lib=static=rln");
+        println!("cargo:rustc-link-lib=c++");
+    } else {
+        println!("cargo:rustc-link-lib=dylib=logosdelivery");
+    }
     println!("cargo:lib_dir={}", lib_dir.display());
 }
 


### PR DESCRIPTION
## What

Adds `ios` to the platform gate in `extensions/logos-delivery-rust/build.rs`, and links the delivery node statically on that platform.

## Why

The gate currently accepts only `macos` and `linux`:

```rust
match target_os.as_str() {
    "macos" | "linux" => {}
    other => panic!("unsupported OS for logos-delivery transport: {other}"),
}
```

so any Apple mobile target panics in the build script before a line of the crate compiles. That single `panic!` is the only thing standing between this workspace and an iOS build — everything downstream of it turned out to work unmodified.

iOS differs from the existing platforms in exactly one respect: an app bundle can't ship a loose dylib the way an APK ships a `.so`, so the node has to be linked as a **static** archive. Two consequences follow:

- `rln` must be named explicitly. With no shared library in the picture there's no rpath to resolve it transitively, the way it is today through `liblogosdelivery.so`'s own `@loader_path`/`$ORIGIN`.
- iOS takes the relocatable path unconditionally, since the absolute-install-name stamping the default path performs is meaningless for a static archive linked into the consumer's binary.

## Verification

Built against this branch on `aarch64-apple-ios-sim`, using the `liblogoschat` C-ABI wrapper from the Android distribution as the consumer:

**Compiles** — `liblogoschat.a`, `Non-fat file: ... architecture: arm64`, `platform IOSSIMULATOR`, 26 exported `logoschat_*` symbols.

**Links** — against `liblogosdelivery.a` + `librln.a` with no unresolved symbols. This is the step that actually exercises the change; a static archive alone wouldn't have caught a wrong link directive.

**Runs** — on an iPhone 17 Pro simulator, the network-free smoke returns a valid account address:

```
$ xcrun simctl spawn <udid> ./smoke
address: ba5172095a7159d1988ea7a37058c256c34d31111037edb27ac85b939f6c8073
```

I also confirmed `cargo build --release --target aarch64-apple-ios-sim -p logos-delivery` succeeds on a clean tree of `main` with only this diff applied, so the change stands on its own without any downstream patches.

## Not covered

Device targets (`aarch64-apple-ios`) are untested. They additionally need `liblogosdelivery.a` and `librln.a` built for the device slice, which lives outside this repo — the archives I verified against are simulator-only. The build-script change itself isn't simulator-specific, but I'd rather flag that than imply device support I haven't run.

No behaviour changes on macOS, Linux, or any existing consumer: every added branch is gated on `target_os == "ios"`.
